### PR TITLE
Fix aliases injected via use

### DIFF
--- a/internal/lsp/elixir.go
+++ b/internal/lsp/elixir.go
@@ -368,9 +368,9 @@ func ExtractImports(text string) []string {
 }
 
 // parseHelperQuoteBlock finds `def/defp helperName` in lines, locates its
-// `quote do` block, and extracts imports/uses/inline-defs from it. Returns
-// nil slices if the function or its quote block can't be found.
-func parseHelperQuoteBlock(lines []string, helperName string, fileAliases map[string]string) (imported []string, inlineDefs map[string][]inlineDef, transUses []string, optBindings []optBinding) {
+// `quote do` block, and extracts imports/uses/inline-defs/aliases from it.
+// Returns nil slices if the function or its quote block can't be found.
+func parseHelperQuoteBlock(lines []string, helperName string, fileAliases map[string]string) (imported []string, inlineDefs map[string][]inlineDef, transUses []string, optBindings []optBinding, aliases map[string]string) {
 	resolveAlias := func(modName string) string {
 		return parser.ResolveModuleRef(modName, fileAliases, "")
 	}
@@ -438,6 +438,33 @@ func parseHelperQuoteBlock(lines []string, helperName string, fileAliases map[st
 		}
 		if m := useRe.FindStringSubmatch(line); m != nil {
 			transUses = append(transUses, resolveAlias(m[1]))
+			continue
+		}
+		if m := parser.AliasAsRe.FindStringSubmatch(line); m != nil {
+			if aliases == nil {
+				aliases = make(map[string]string)
+			}
+			aliases[m[2]] = resolveAlias(m[1])
+			continue
+		} else if m := aliasMultiRe.FindStringSubmatch(line); m != nil {
+			base := resolveAlias(m[1])
+			for _, name := range strings.Split(m[2], ",") {
+				name = strings.TrimSpace(name)
+				if len(name) > 0 && unicode.IsUpper(rune(name[0])) {
+					if aliases == nil {
+						aliases = make(map[string]string)
+					}
+					aliases[name] = base + "." + name
+				}
+			}
+			continue
+		} else if m := parser.AliasRe.FindStringSubmatch(line); m != nil {
+			resolved := resolveAlias(m[1])
+			parts := strings.Split(resolved, ".")
+			if aliases == nil {
+				aliases = make(map[string]string)
+			}
+			aliases[parts[len(parts)-1]] = resolved
 			continue
 		}
 		if m := parser.FuncDefRe.FindStringSubmatch(line); m != nil {
@@ -513,10 +540,11 @@ type inlineDef struct {
 }
 
 // parseUsingBody finds the defmacro __using__ block in text and scans its body
-// for import statements, inline function definitions, transitive use calls, and
+// for import statements, inline function definitions, transitive use calls,
 // dynamic opt-driven imports (e.g. `import unquote(mod)` where `mod` comes from
-// a Keyword.get on opts).
-func parseUsingBody(text string) (imported []string, inlineDefs map[string][]inlineDef, transUses []string, optBindings []optBinding) {
+// a Keyword.get on opts), and alias declarations that get injected into the
+// consumer module.
+func parseUsingBody(text string) (imported []string, inlineDefs map[string][]inlineDef, transUses []string, optBindings []optBinding, aliases map[string]string) {
 	lines := strings.Split(text, "\n")
 	fileAliases := extractAliasesFromLines(lines, -1)
 
@@ -649,18 +677,54 @@ func parseUsingBody(text string) (imported []string, inlineDefs map[string][]inl
 			continue
 		}
 
+		// Alias declarations injected into the consumer module
+		if m := parser.AliasAsRe.FindStringSubmatch(line); m != nil {
+			if aliases == nil {
+				aliases = make(map[string]string)
+			}
+			aliases[m[2]] = resolveAlias(m[1])
+			continue
+		} else if m := aliasMultiRe.FindStringSubmatch(line); m != nil {
+			base := resolveAlias(m[1])
+			for _, name := range strings.Split(m[2], ",") {
+				name = strings.TrimSpace(name)
+				if len(name) > 0 && unicode.IsUpper(rune(name[0])) {
+					if aliases == nil {
+						aliases = make(map[string]string)
+					}
+					aliases[name] = base + "." + name
+				}
+			}
+			continue
+		} else if m := parser.AliasRe.FindStringSubmatch(line); m != nil {
+			resolved := resolveAlias(m[1])
+			parts := strings.Split(resolved, ".")
+			if aliases == nil {
+				aliases = make(map[string]string)
+			}
+			aliases[parts[len(parts)-1]] = resolved
+			continue
+		}
+
 		// Delegation to a helper function: `using_block(opts)` or similar.
 		// Find that function's definition in the same file and parse its
 		// quote do block, which contains the actual imports/uses to inject.
 		if m := bareCallRe.FindStringSubmatch(line); m != nil {
 			helperName := m[1]
-			if helperImported, helperDefs, helperTransUses, helperBindings := parseHelperQuoteBlock(lines, helperName, fileAliases); helperImported != nil {
+			helperImported, helperDefs, helperTransUses, helperBindings, helperAliases := parseHelperQuoteBlock(lines, helperName, fileAliases)
+			if helperImported != nil {
 				imported = append(imported, helperImported...)
 				for k, v := range helperDefs {
 					inlineDefs[k] = append(inlineDefs[k], v...)
 				}
 				transUses = append(transUses, helperTransUses...)
 				optBindings = append(optBindings, helperBindings...)
+			}
+			for k, v := range helperAliases {
+				if aliases == nil {
+					aliases = make(map[string]string)
+				}
+				aliases[k] = v
 			}
 			continue
 		}

--- a/internal/lsp/elixir.go
+++ b/internal/lsp/elixir.go
@@ -367,6 +367,43 @@ func ExtractImports(text string) []string {
 	return imports
 }
 
+// extractAliasFromLine checks whether line matches an alias declaration
+// (alias X, as: Y / alias X.{A, B} / alias X.Y) and, if so, records it in
+// aliases and returns the (possibly newly-created) map plus true. Returns
+// (aliases, false) when the line is not an alias declaration.
+func extractAliasFromLine(line string, aliases map[string]string, resolveAlias func(string) string) (map[string]string, bool) {
+	if m := parser.AliasAsRe.FindStringSubmatch(line); m != nil {
+		if aliases == nil {
+			aliases = make(map[string]string)
+		}
+		aliases[m[2]] = resolveAlias(m[1])
+		return aliases, true
+	}
+	if m := aliasMultiRe.FindStringSubmatch(line); m != nil {
+		base := resolveAlias(m[1])
+		for _, name := range strings.Split(m[2], ",") {
+			name = strings.TrimSpace(name)
+			if len(name) > 0 && unicode.IsUpper(rune(name[0])) {
+				if aliases == nil {
+					aliases = make(map[string]string)
+				}
+				aliases[name] = base + "." + name
+			}
+		}
+		return aliases, true
+	}
+	if m := parser.AliasRe.FindStringSubmatch(line); m != nil {
+		resolved := resolveAlias(m[1])
+		parts := strings.Split(resolved, ".")
+		if aliases == nil {
+			aliases = make(map[string]string)
+		}
+		aliases[parts[len(parts)-1]] = resolved
+		return aliases, true
+	}
+	return aliases, false
+}
+
 // parseHelperQuoteBlock finds `def/defp helperName` in lines, locates its
 // `quote do` block, and extracts imports/uses/inline-defs/aliases from it.
 // Returns nil slices if the function or its quote block can't be found.
@@ -440,31 +477,8 @@ func parseHelperQuoteBlock(lines []string, helperName string, fileAliases map[st
 			transUses = append(transUses, resolveAlias(m[1]))
 			continue
 		}
-		if m := parser.AliasAsRe.FindStringSubmatch(line); m != nil {
-			if aliases == nil {
-				aliases = make(map[string]string)
-			}
-			aliases[m[2]] = resolveAlias(m[1])
-			continue
-		} else if m := aliasMultiRe.FindStringSubmatch(line); m != nil {
-			base := resolveAlias(m[1])
-			for _, name := range strings.Split(m[2], ",") {
-				name = strings.TrimSpace(name)
-				if len(name) > 0 && unicode.IsUpper(rune(name[0])) {
-					if aliases == nil {
-						aliases = make(map[string]string)
-					}
-					aliases[name] = base + "." + name
-				}
-			}
-			continue
-		} else if m := parser.AliasRe.FindStringSubmatch(line); m != nil {
-			resolved := resolveAlias(m[1])
-			parts := strings.Split(resolved, ".")
-			if aliases == nil {
-				aliases = make(map[string]string)
-			}
-			aliases[parts[len(parts)-1]] = resolved
+		if updated, matched := extractAliasFromLine(line, aliases, resolveAlias); matched {
+			aliases = updated
 			continue
 		}
 		if m := parser.FuncDefRe.FindStringSubmatch(line); m != nil {
@@ -677,32 +691,8 @@ func parseUsingBody(text string) (imported []string, inlineDefs map[string][]inl
 			continue
 		}
 
-		// Alias declarations injected into the consumer module
-		if m := parser.AliasAsRe.FindStringSubmatch(line); m != nil {
-			if aliases == nil {
-				aliases = make(map[string]string)
-			}
-			aliases[m[2]] = resolveAlias(m[1])
-			continue
-		} else if m := aliasMultiRe.FindStringSubmatch(line); m != nil {
-			base := resolveAlias(m[1])
-			for _, name := range strings.Split(m[2], ",") {
-				name = strings.TrimSpace(name)
-				if len(name) > 0 && unicode.IsUpper(rune(name[0])) {
-					if aliases == nil {
-						aliases = make(map[string]string)
-					}
-					aliases[name] = base + "." + name
-				}
-			}
-			continue
-		} else if m := parser.AliasRe.FindStringSubmatch(line); m != nil {
-			resolved := resolveAlias(m[1])
-			parts := strings.Split(resolved, ".")
-			if aliases == nil {
-				aliases = make(map[string]string)
-			}
-			aliases[parts[len(parts)-1]] = resolved
+		if updated, matched := extractAliasFromLine(line, aliases, resolveAlias); matched {
+			aliases = updated
 			continue
 		}
 

--- a/internal/lsp/elixir_test.go
+++ b/internal/lsp/elixir_test.go
@@ -706,7 +706,7 @@ func TestExtractUsingImports(t *testing.T) {
     :ok
   end
 end`
-		imports, _, _, _ := parseUsingBody(text)
+		imports, _, _, _, _ := parseUsingBody(text)
 		if len(imports) != 2 {
 			t.Fatalf("expected 2 imports, got %d: %v", len(imports), imports)
 		}
@@ -729,7 +729,7 @@ end`
 
   def other_func, do: :ok
 end`
-		imports, _, _, _ := parseUsingBody(text)
+		imports, _, _, _, _ := parseUsingBody(text)
 		if len(imports) != 1 || imports[0] != "Foo" {
 			t.Errorf("expected [Foo], got %v", imports)
 		}
@@ -737,7 +737,7 @@ end`
 
 	t.Run("no __using__ returns nil", func(t *testing.T) {
 		text := "defmodule Lib do\n  def foo, do: :ok\nend"
-		imports, _, _, _ := parseUsingBody(text)
+		imports, _, _, _, _ := parseUsingBody(text)
 		if len(imports) != 0 {
 			t.Errorf("expected no imports, got %v", imports)
 		}
@@ -757,7 +757,7 @@ func TestExtractUsingInlineDefs(t *testing.T) {
 end`
 
 	inlineDefsOf := func(name string) []int {
-		_, defs, _, _ := parseUsingBody(text)
+		_, defs, _, _, _ := parseUsingBody(text)
 		var lines []int
 		for _, d := range defs[name] {
 			lines = append(lines, d.line)
@@ -798,7 +798,7 @@ func TestParseUsingBody_InlineDefArity(t *testing.T) {
     end
   end
 end`
-	_, inlineDefs, _, _ := parseUsingBody(text)
+	_, inlineDefs, _, _, _ := parseUsingBody(text)
 
 	check := func(name string, wantArity int, wantKind string) {
 		t.Helper()
@@ -831,7 +831,7 @@ func TestParseUsingBody_SkipsUnquoteUse(t *testing.T) {
     end
   end
 end`
-	_, _, transUses, _ := parseUsingBody(text)
+	_, _, transUses, _, _ := parseUsingBody(text)
 	for _, u := range transUses {
 		if u == "unquote" {
 			t.Error("transUses should not contain 'unquote'")
@@ -850,7 +850,7 @@ func TestParseUsingBody_KeywordModuleHints(t *testing.T) {
     end
   end
 end`
-		_, _, transUses, _ := parseUsingBody(text)
+		_, _, transUses, _, _ := parseUsingBody(text)
 		found := false
 		for _, u := range transUses {
 			if u == "Oban.Pro.Worker" {
@@ -872,7 +872,7 @@ end`
     end
   end
 end`
-		_, _, _, optBindings := parseUsingBody(text)
+		_, _, _, optBindings, _ := parseUsingBody(text)
 		found := false
 		for _, b := range optBindings {
 			if b.optKey == "base_module" && b.defaultMod == "MyLib.DefaultBase" && b.kind == "use" {
@@ -894,7 +894,7 @@ end`
     end
   end
 end`
-		_, _, transUses, _ := parseUsingBody(text)
+		_, _, transUses, _, _ := parseUsingBody(text)
 		for _, u := range transUses {
 			if u == "false" {
 				t.Error("transUses should not contain 'false'")
@@ -916,7 +916,7 @@ func TestParseUsingBody_CaseTemplateUsing(t *testing.T) {
   end
 end
 `
-		imported, _, _, _ := parseUsingBody(text)
+		imported, _, _, _, _ := parseUsingBody(text)
 		foundConn, foundHelpers := false, false
 		for _, imp := range imported {
 			if imp == "Phoenix.ConnTest" {
@@ -952,7 +952,7 @@ end
     using_block(opts)
   end
 end`
-		imported, _, transUses, _ := parseUsingBody(text)
+		imported, _, transUses, _, _ := parseUsingBody(text)
 
 		foundConn, foundPlug := false, false
 		for _, imp := range imported {
@@ -989,7 +989,7 @@ end`
     :ok
   end
 end`
-		imported, _, _, _ := parseUsingBody(text)
+		imported, _, _, _, _ := parseUsingBody(text)
 		if len(imported) != 0 {
 			t.Errorf("expected no imports for non-CaseTemplate using, got %v", imported)
 		}
@@ -1007,7 +1007,7 @@ func TestParseUsingBody_UnquoteImport(t *testing.T) {
     end
   end
 end`
-		imported, _, _, optBindings := parseUsingBody(text)
+		imported, _, _, optBindings, _ := parseUsingBody(text)
 		// Dynamic unquote imports should NOT be in static imports
 		for _, imp := range imported {
 			if imp == "Mox" {
@@ -1041,7 +1041,7 @@ end`
     end
   end
 end`
-		_, _, _, optBindings := parseUsingBody(text)
+		_, _, _, optBindings, _ := parseUsingBody(text)
 		if len(optBindings) == 0 {
 			t.Fatal("expected opt binding")
 		}
@@ -1066,7 +1066,7 @@ end`
     end
   end
 end`
-		_, _, transUses, optBindings := parseUsingBody(text)
+		_, _, transUses, optBindings, _ := parseUsingBody(text)
 		// Dynamic unquote uses should NOT be in static transUses
 		for _, u := range transUses {
 			if u == "MyLib.Base" {
@@ -1076,6 +1076,97 @@ end`
 		_ = transUses
 		if len(optBindings) == 0 || optBindings[0].kind != "use" {
 			t.Errorf("expected a 'use' opt binding, got %v", optBindings)
+		}
+	})
+}
+
+func TestParseUsingBody_Aliases(t *testing.T) {
+	t.Run("simple alias", func(t *testing.T) {
+		text := `defmodule MyApp.Schema do
+  defmacro __using__(_opts) do
+    quote do
+      alias MyApp.Repo
+      alias MyApp.Accounts.User
+      import Ecto.Query
+    end
+  end
+end`
+		_, _, _, _, aliases := parseUsingBody(text)
+		if aliases == nil {
+			t.Fatal("expected aliases, got nil")
+		}
+		if aliases["Repo"] != "MyApp.Repo" {
+			t.Errorf("Repo: got %q, want MyApp.Repo", aliases["Repo"])
+		}
+		if aliases["User"] != "MyApp.Accounts.User" {
+			t.Errorf("User: got %q, want MyApp.Accounts.User", aliases["User"])
+		}
+	})
+
+	t.Run("alias with as:", func(t *testing.T) {
+		text := `defmodule MyApp.Schema do
+  defmacro __using__(_opts) do
+    quote do
+      alias MyApp.Accounts.UserProfile, as: Profile
+    end
+  end
+end`
+		_, _, _, _, aliases := parseUsingBody(text)
+		if aliases == nil {
+			t.Fatal("expected aliases, got nil")
+		}
+		if aliases["Profile"] != "MyApp.Accounts.UserProfile" {
+			t.Errorf("Profile: got %q, want MyApp.Accounts.UserProfile", aliases["Profile"])
+		}
+	})
+
+	t.Run("multi alias", func(t *testing.T) {
+		text := `defmodule MyApp.Schema do
+  defmacro __using__(_opts) do
+    quote do
+      alias MyApp.{Repo, Config, Helper}
+    end
+  end
+end`
+		_, _, _, _, aliases := parseUsingBody(text)
+		if aliases == nil {
+			t.Fatal("expected aliases, got nil")
+		}
+		if aliases["Repo"] != "MyApp.Repo" {
+			t.Errorf("Repo: got %q, want MyApp.Repo", aliases["Repo"])
+		}
+		if aliases["Config"] != "MyApp.Config" {
+			t.Errorf("Config: got %q, want MyApp.Config", aliases["Config"])
+		}
+		if aliases["Helper"] != "MyApp.Helper" {
+			t.Errorf("Helper: got %q, want MyApp.Helper", aliases["Helper"])
+		}
+	})
+
+	t.Run("alias resolved through file-level alias", func(t *testing.T) {
+		text := `defmodule MyApp.Schema do
+  alias Remote.Ecto.Schema, as: EctoSchema
+
+  defmacro __using__(_opts) do
+    quote do
+      alias EctoSchema.Fields
+    end
+  end
+end`
+		_, _, _, _, aliases := parseUsingBody(text)
+		if aliases == nil {
+			t.Fatal("expected aliases, got nil")
+		}
+		if aliases["Fields"] != "Remote.Ecto.Schema.Fields" {
+			t.Errorf("Fields: got %q, want Remote.Ecto.Schema.Fields", aliases["Fields"])
+		}
+	})
+
+	t.Run("no __using__ returns nil aliases", func(t *testing.T) {
+		text := "defmodule Lib do\n  def foo, do: :ok\nend"
+		_, _, _, _, aliases := parseUsingBody(text)
+		if aliases != nil {
+			t.Errorf("expected nil aliases, got %v", aliases)
 		}
 	})
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -48,6 +48,7 @@ type usingCacheEntry struct {
 	inlineDefs  map[string][]inlineDef // function name → inline defs in quote do block
 	transUses   []string               // modules used inside __using__ body (double-use chains)
 	optBindings []optBinding           // dynamic imports/uses resolved from opts
+	aliases     map[string]string      // alias short name → full module injected by __using__
 }
 
 type Server struct {
@@ -565,6 +566,7 @@ func (s *Server) Definition(ctx context.Context, params *protocol.DefinitionPara
 
 	moduleRef, functionName := ExtractModuleAndFunction(expr)
 	aliases := ExtractAliasesInScope(text, lineNum)
+	s.mergeAliasesFromUse(text, aliases)
 	s.debugf("Definition: expr=%q module=%q function=%q", expr, moduleRef, functionName)
 
 	// Bare identifier — check variable first (cheap tree-sitter lookup), then functions
@@ -800,6 +802,7 @@ func (s *Server) CodeAction(ctx context.Context, params *protocol.CodeActionPara
 	}
 
 	aliases := ExtractAliasesInScope(text, lineNum)
+	s.mergeAliasesFromUse(text, aliases)
 
 	// Check if the first segment is already aliased — if so, the reference
 	// already resolves and no code action is needed.
@@ -976,6 +979,7 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 
 	if moduleRef != "" && (afterDot || funcPrefix != "") {
 		aliases := ExtractAliases(text)
+		s.mergeAliasesFromUse(text, aliases)
 		resolved := resolveModule(moduleRef, aliases)
 		results, err := s.store.ListModuleFunctions(resolved, true)
 		if err != nil {
@@ -1012,6 +1016,7 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 		}
 	} else if moduleRef != "" {
 		aliases := ExtractAliases(text)
+		s.mergeAliasesFromUse(text, aliases)
 		seenModules := make(map[string]bool)
 
 		addModuleItem := func(label, detail string) {
@@ -1112,6 +1117,7 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 
 		// Check use-injected imports and inline defs (including transitive use chains)
 		aliases := ExtractAliases(text)
+		s.mergeAliasesFromUse(text, aliases)
 		visitedCompletion := make(map[string]bool)
 		for _, usedModule := range ExtractUses(text) {
 			s.addCompletionsFromUsing(resolveModule(usedModule, aliases), funcPrefix, seen, &items, visitedCompletion, inPipe, s.snippetSupport)
@@ -1209,7 +1215,7 @@ func (s *Server) parseUsingFile(filePath string) *usingCacheEntry {
 	if err != nil {
 		return nil
 	}
-	imported, inlineDefs, transUses, optBindings := parseUsingBody(string(fileData))
+	imported, inlineDefs, transUses, optBindings, aliases := parseUsingBody(string(fileData))
 	return &usingCacheEntry{
 		mtime:       info.ModTime().UnixNano(),
 		filePath:    filePath,
@@ -1217,6 +1223,7 @@ func (s *Server) parseUsingFile(filePath string) *usingCacheEntry {
 		inlineDefs:  inlineDefs,
 		transUses:   transUses,
 		optBindings: optBindings,
+		aliases:     aliases,
 	}
 }
 
@@ -1595,6 +1602,40 @@ func resolveModule(moduleRef string, aliases map[string]string) string {
 	return moduleRef
 }
 
+// mergeAliasesFromUse augments the alias map with aliases injected by `use`
+// declarations in the file. For example, if the file has `use MyApp.Schema`
+// and MyApp.Schema.__using__ contains `alias MyApp.Repo`, then Repo is added.
+func (s *Server) mergeAliasesFromUse(text string, aliases map[string]string) {
+	useCalls := ExtractUsesWithOpts(text, aliases)
+	visited := make(map[string]bool)
+	for _, uc := range useCalls {
+		s.mergeAliasesFromUsingEntry(uc.Module, aliases, visited)
+	}
+}
+
+func (s *Server) mergeAliasesFromUsingEntry(moduleName string, aliases map[string]string, visited map[string]bool) {
+	if visited[moduleName] {
+		return
+	}
+	visited[moduleName] = true
+
+	entry := s.cachedUsing(moduleName)
+	if entry == nil {
+		return
+	}
+
+	for short, full := range entry.aliases {
+		if _, exists := aliases[short]; !exists {
+			aliases[short] = full
+		}
+	}
+
+	// Follow transitive uses
+	for _, transModule := range entry.transUses {
+		s.mergeAliasesFromUsingEntry(transModule, aliases, visited)
+	}
+}
+
 // resolveModuleWithNesting resolves a module reference, falling back to the
 // implicit alias created by nested defmodule declarations. In Elixir,
 // `defmodule Inner do` inside `defmodule Outer do` creates an implicit alias
@@ -1850,6 +1891,7 @@ func (s *Server) Declaration(ctx context.Context, params *protocol.DeclarationPa
 	// is specified as a keyword opt (e.g. oban_module: Oban.Pro.Worker).
 	if len(locations) == 0 && functionName != "" {
 		aliases := ExtractAliasesInScope(text, lineNum)
+		s.mergeAliasesFromUse(text, aliases)
 		if callbacks := s.findCallbacksViaUseChain(text, functionName, arity, aliases); len(callbacks) > 0 {
 			s.debugf("Declaration: found %d callbacks via use-chain for %s/%d", len(callbacks), functionName, arity)
 			for _, cb := range callbacks {
@@ -2611,6 +2653,7 @@ func (s *Server) Hover(ctx context.Context, params *protocol.HoverParams) (*prot
 
 	moduleRef, functionName := ExtractModuleAndFunction(expr)
 	aliases := ExtractAliasesInScope(text, lineNum)
+	s.mergeAliasesFromUse(text, aliases)
 
 	if moduleRef == "" {
 		if functionName == "" {
@@ -2786,6 +2829,7 @@ func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRena
 	// Try module/function rename via the index
 	if expr != "" {
 		aliases := ExtractAliasesInScope(text, lineNum)
+		s.mergeAliasesFromUse(text, aliases)
 
 		// Detect `as:` aliases — these are file-local renames, not module renames.
 		// An `as:` alias has a short name that differs from the last segment of
@@ -2937,6 +2981,7 @@ func (s *Server) References(ctx context.Context, params *protocol.ReferenceParam
 
 	moduleRef, functionName := ExtractModuleAndFunction(expr)
 	aliases := ExtractAliasesInScope(text, lineNum)
+	s.mergeAliasesFromUse(text, aliases)
 	s.debugf("References: expr=%q module=%q function=%q", expr, moduleRef, functionName)
 
 	var fullModule string
@@ -3178,6 +3223,7 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 	// Try module/function rename via the index
 	if expr != "" {
 		aliases := ExtractAliasesInScope(text, lineNum)
+		s.mergeAliasesFromUse(text, aliases)
 
 		// Detect `as:` aliases — file-local rename of the alias name, not
 		// the underlying module.
@@ -4208,6 +4254,7 @@ func (s *Server) SignatureHelp(ctx context.Context, params *protocol.SignatureHe
 	}
 
 	aliases := ExtractAliasesInScope(text, lineNum)
+	s.mergeAliasesFromUse(text, aliases)
 	lines := strings.Split(text, "\n")
 
 	// Resolve the function to a store lookup result
@@ -4371,6 +4418,7 @@ func (s *Server) TypeDefinition(ctx context.Context, params *protocol.TypeDefini
 	}
 
 	aliases := ExtractAliasesInScope(text, lineNum)
+	s.mergeAliasesFromUse(text, aliases)
 	fullModule := s.resolveModuleWithNesting(moduleRef, aliases, uriToPath(protocol.DocumentURI(docURI)), lineNum)
 
 	results, err := s.store.LookupFunction(fullModule, typeName)
@@ -4445,6 +4493,7 @@ func (s *Server) PrepareCallHierarchy(ctx context.Context, params *protocol.Call
 	}
 
 	aliases := ExtractAliasesInScope(text, lineNum)
+	s.mergeAliasesFromUse(text, aliases)
 	var fullModule string
 	if moduleRef != "" {
 		fullModule = resolveModule(moduleRef, aliases)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -2829,11 +2829,13 @@ func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRena
 	// Try module/function rename via the index
 	if expr != "" {
 		aliases := ExtractAliasesInScope(text, lineNum)
-		s.mergeAliasesFromUse(text, aliases)
 
 		// Detect `as:` aliases — these are file-local renames, not module renames.
 		// An `as:` alias has a short name that differs from the last segment of
 		// the resolved module (e.g. TransactionReceiptSchema → MyApp.Billing.TransactionReceipt).
+		// This check runs before merging use-injected aliases because those
+		// declarations live in another file's __using__ macro and must not be
+		// treated as file-local renames.
 		if moduleRef != "" && functionName == "" {
 			if resolved, ok := aliases[moduleRef]; ok && moduleLastSegment(resolved) != moduleRef {
 				// File-local alias rename: find all occurrences in this file
@@ -2843,6 +2845,8 @@ func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRena
 				}, nil
 			}
 		}
+
+		s.mergeAliasesFromUse(text, aliases)
 
 		var tokenName string
 		var fullModule string
@@ -3223,10 +3227,11 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 	// Try module/function rename via the index
 	if expr != "" {
 		aliases := ExtractAliasesInScope(text, lineNum)
-		s.mergeAliasesFromUse(text, aliases)
 
 		// Detect `as:` aliases — file-local rename of the alias name, not
-		// the underlying module.
+		// the underlying module. This check runs before merging use-injected
+		// aliases because those declarations live in another file's __using__
+		// macro and must not be treated as file-local renames.
 		if moduleRef != "" && functionName == "" {
 			if resolved, ok := aliases[moduleRef]; ok && moduleLastSegment(resolved) != moduleRef {
 				if !isValidModuleName(params.NewName) {
@@ -3254,6 +3259,8 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 				return &protocol.WorkspaceEdit{Changes: changes}, nil
 			}
 		}
+
+		s.mergeAliasesFromUse(text, aliases)
 
 		if functionName != "" {
 			var fullModule string

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -1528,6 +1528,106 @@ end`
 	}
 }
 
+func TestDefinition_AliasInjectedByUse(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	// MyApp.Schema.__using__ injects `alias MyApp.Meta` into consumer modules.
+	// Go-to-definition on `Meta.source(x)` should resolve Meta → MyApp.Meta
+	// via the use-injected alias.
+	schemaSrc := `defmodule MyApp.Schema do
+  defmacro __using__(_opts) do
+    quote do
+      alias MyApp.Meta
+      alias MyApp.Config
+    end
+  end
+end`
+	metaSrc := `defmodule MyApp.Meta do
+  def source(x), do: x
+end`
+	callerSrc := `defmodule MyApp.MyCheck do
+  use MyApp.Schema
+
+  def run do
+    Meta.source(:foo)
+  end
+end`
+
+	indexFile(t, server.store, server.projectRoot, "lib/schema.ex", schemaSrc)
+	schemaURI := "file://" + filepath.Join(server.projectRoot, "lib/schema.ex")
+	server.docs.Set(schemaURI, schemaSrc)
+
+	indexFile(t, server.store, server.projectRoot, "lib/meta.ex", metaSrc)
+
+	callerURI := "file://" + filepath.Join(server.projectRoot, "lib/my_check.ex")
+	server.docs.Set(callerURI, callerSrc)
+
+	// line 4 (0-indexed): `    Meta.source(:foo)` — col 4 is on `Meta`
+	locs := definitionAt(t, server, callerURI, 4, 4)
+	if len(locs) == 0 {
+		t.Fatal("expected go-to-definition for `Meta` resolved via alias injected by `use MyApp.Schema`")
+	}
+
+	// Should resolve to the MyApp.Meta module definition
+	found := false
+	for _, loc := range locs {
+		if strings.Contains(string(loc.URI), "meta.ex") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected definition location in meta.ex, got %v", locs)
+	}
+}
+
+func TestHover_AliasInjectedByUse(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	schemaSrc := `defmodule MyApp.Schema do
+  defmacro __using__(_opts) do
+    quote do
+      alias MyApp.Meta
+    end
+  end
+end`
+	metaSrc := `defmodule MyApp.Meta do
+  @doc "Returns the source from meta"
+  def source(x), do: x
+end`
+	callerSrc := `defmodule MyApp.MyCheck do
+  use MyApp.Schema
+
+  def run do
+    Meta.source(:foo)
+  end
+end`
+
+	indexFile(t, server.store, server.projectRoot, "lib/schema.ex", schemaSrc)
+	schemaURI := "file://" + filepath.Join(server.projectRoot, "lib/schema.ex")
+	server.docs.Set(schemaURI, schemaSrc)
+
+	indexFile(t, server.store, server.projectRoot, "lib/meta.ex", metaSrc)
+
+	callerURI := "file://" + filepath.Join(server.projectRoot, "lib/my_check.ex")
+	server.docs.Set(callerURI, callerSrc)
+
+	// line 4 (0-indexed): `    Meta.source(:foo)` — col 9 is on `source`
+	hover, err := server.Hover(context.Background(), &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI(callerURI)},
+			Position:     protocol.Position{Line: 4, Character: 9},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hover == nil {
+		t.Fatal("expected hover result for Meta.source resolved via use-injected alias, got nil")
+	}
+}
+
 func TestReferences_UseWithOptOverride(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core Elixir LSP resolution paths (definition/hover/completion/rename/references) by expanding alias resolution using cached `__using__` parsing; mistakes could cause widespread mis-resolutions or performance regressions on large projects.
> 
> **Overview**
> Fixes module resolution when a consumer relies on aliases injected by `use` macros.
> 
> `parseUsingBody`/`parseHelperQuoteBlock` now extract `alias` declarations (including `as:` and multi-alias forms) from `__using__`/helper `quote do` blocks and store them in the `usingCacheEntry`. The server merges these use-injected aliases (including transitive `use` chains) into the in-scope alias map for definition/hover/completion/actions and ensures rename logic still treats only *file-local* `as:` aliases as renames.
> 
> Adds unit tests covering alias extraction from `__using__` and go-to-definition/hover resolution through a use-injected alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c11912e1e01797d272c37f6259f1628fc1b581f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->