### PR TITLE
Fix depth detection and respect formatting config

### DIFF
--- a/internal/lsp/elixir.go
+++ b/internal/lsp/elixir.go
@@ -272,12 +272,26 @@ func extractAliasesFromLines(lines []string, targetLine int) map[string]string {
 	}
 	var targetModule string
 	unscoped := targetLine < 0
+	inHeredoc := false
 
 	for i, line := range lines {
+		var skip bool
+		inHeredoc, skip = parser.CheckHeredoc(line, inHeredoc)
+		if skip {
+			// Still track targetLine so scope is correct for lines inside heredocs
+			if i == targetLine {
+				if len(stack) > 0 {
+					targetModule = stack[len(stack)-1].name
+				}
+			}
+			continue
+		}
+
 		trimmed := strings.TrimSpace(line)
+		stripped := strings.TrimSpace(parser.StripCommentsAndStrings(trimmed))
 
 		// Track do..end nesting
-		if trimmed == "end" {
+		if parser.IsEnd(stripped) {
 			if len(stack) > 0 && stack[len(stack)-1].depth == depth {
 				stack = stack[:len(stack)-1]
 			}
@@ -287,15 +301,16 @@ func extractAliasesFromLines(lines []string, targetLine int) map[string]string {
 			}
 		}
 
-		if m := parser.DefmoduleRe.FindStringSubmatch(line); m != nil {
+		if parser.OpensBlock(stripped) {
+			depth++
+		}
+
+		if m := parser.DefmoduleRe.FindStringSubmatch(trimmed); m != nil {
 			name := m[1]
 			if !strings.Contains(name, ".") && len(stack) > 0 {
 				name = stack[len(stack)-1].name + "." + name
 			}
-			depth++
 			stack = append(stack, moduleFrame{name, depth})
-		} else if parser.ContainsDo(trimmed) {
-			depth++
 		}
 
 		currentModule := ""

--- a/internal/lsp/elixir_test.go
+++ b/internal/lsp/elixir_test.go
@@ -424,6 +424,29 @@ end
 			t.Errorf("expected Settings alias with do/end in strings, got %q", aliases["Settings"])
 		}
 	})
+
+	t.Run("trailing fn with no args does not break scope", func(t *testing.T) {
+		// Regression: "handler = fn" at end of line was not detected by ContainsFn
+		// because all patterns required a space after "fn".
+		trailingFnSrc := `defmodule MyApp.Builder do
+  alias MyApp.Validator
+
+  def build do
+    handler = fn
+      :ok -> true
+      :error -> false
+    end
+
+    Validator.run(handler)
+  end
+end
+`
+		// Line 10 = "Validator.run(handler)" — should still see aliases
+		aliases := ExtractAliasesInScope(trailingFnSrc, 10)
+		if aliases["Validator"] != "MyApp.Validator" {
+			t.Errorf("expected Validator alias after trailing fn, got %q", aliases["Validator"])
+		}
+	})
 }
 
 func TestExtractImports(t *testing.T) {

--- a/internal/lsp/elixir_test.go
+++ b/internal/lsp/elixir_test.go
@@ -333,6 +333,97 @@ end
 			t.Error("TransactionRecord alias should NOT be visible in outer scope")
 		}
 	})
+
+	t.Run("fn...end block does not break scope tracking", func(t *testing.T) {
+		// Regression: fn...end has an "end" without a corresponding "do",
+		// which caused the depth counter to go out of sync and pop the
+		// module scope prematurely.
+		fnSrc := `defmodule MyApp.Aggregator do
+  alias MyApp.Filters
+
+  defp build_filter(:active, items) do
+    codes =
+      Filters.get_codes(items) ++
+        Filters.get_extra_codes(items)
+
+    fn item ->
+      item.code in codes
+    end
+  end
+
+  def run(items) do
+    Filters.all(items)
+  end
+end
+`
+		// Line 14 = "def run" — should still see aliases from the module scope
+		aliases := ExtractAliasesInScope(fnSrc, 14)
+		if aliases["Filters"] != "MyApp.Filters" {
+			t.Errorf("expected Filters alias after fn...end block, got %q", aliases["Filters"])
+		}
+	})
+
+	t.Run("fn with end in comment does not confuse depth", func(t *testing.T) {
+		commentSrc := `defmodule MyApp.Worker do
+  alias MyApp.Processor
+
+  defp make_handler(items) do
+    fn -> # this is something in the end
+      Processor.run(items)
+    end
+  end
+
+  def execute(items) do
+    Processor.start(items)
+  end
+end
+`
+		// Line 10 = "def execute" — should still see aliases
+		aliases := ExtractAliasesInScope(commentSrc, 10)
+		if aliases["Processor"] != "MyApp.Processor" {
+			t.Errorf("expected Processor alias after fn with end-in-comment, got %q", aliases["Processor"])
+		}
+	})
+
+	t.Run("heredoc containing end does not break scope", func(t *testing.T) {
+		heredocSrc := `defmodule MyApp.Docs do
+  alias MyApp.Formatter
+
+  @moduledoc """
+  end
+  some text
+  end
+  """
+
+  def render(text) do
+    Formatter.run(text)
+  end
+end
+`
+		// Line 10 = "def render" — should still see aliases despite "end" lines in heredoc
+		aliases := ExtractAliasesInScope(heredocSrc, 10)
+		if aliases["Formatter"] != "MyApp.Formatter" {
+			t.Errorf("expected Formatter alias after heredoc with end lines, got %q", aliases["Formatter"])
+		}
+	})
+
+	t.Run("string containing do or end does not affect depth", func(t *testing.T) {
+		stringSrc := `defmodule MyApp.Config do
+  alias MyApp.Settings
+
+  def label do
+    x = "something do"
+    y = "end"
+    Settings.get(x, y)
+  end
+end
+`
+		// Line 7 = "Settings.get(x, y)" — aliases should still resolve
+		aliases := ExtractAliasesInScope(stringSrc, 7)
+		if aliases["Settings"] != "MyApp.Settings" {
+			t.Errorf("expected Settings alias with do/end in strings, got %q", aliases["Settings"])
+		}
+	})
 }
 
 func TestExtractImports(t *testing.T) {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -368,7 +368,7 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 			TextDocumentSync: protocol.TextDocumentSyncOptions{
 				OpenClose:         true,
 				Change:            protocol.TextDocumentSyncKindFull,
-				WillSaveWaitUntil: true,
+				WillSaveWaitUntil: false,
 				Save: &protocol.SaveOptions{
 					IncludeText: false,
 				},
@@ -2515,14 +2515,17 @@ func (s *Server) FoldingRanges(ctx context.Context, params *protocol.FoldingRang
 		}
 		indent := len(line) - len(strings.TrimLeft(line, " \t"))
 
-		// Check for do blocks: "... do" at end of line
-		if strings.HasSuffix(trimmed, " do") || strings.HasSuffix(trimmed, "\tdo") || trimmed == "do" {
+		// Strip strings/comments for block detection so content like
+		// `x = "foo do"` doesn't create a false folding range.
+		stripped := strings.TrimSpace(parser.StripCommentsAndStrings(trimmed))
+
+		if parser.OpensBlock(stripped) {
 			stack = append(stack, blockStart{line: i, indent: indent})
 			continue
 		}
 
 		// Pop on "end" at matching indent
-		if trimmed == "end" && len(stack) > 0 {
+		if parser.IsEnd(stripped) && len(stack) > 0 {
 			top := stack[len(stack)-1]
 			if indent == top.indent {
 				stack = stack[:len(stack)-1]
@@ -4394,9 +4397,7 @@ func (s *Server) WillSave(ctx context.Context, params *protocol.WillSaveTextDocu
 	return nil
 }
 func (s *Server) WillSaveWaitUntil(ctx context.Context, params *protocol.WillSaveTextDocumentParams) ([]protocol.TextEdit, error) {
-	return s.Formatting(ctx, &protocol.DocumentFormattingParams{
-		TextDocument: protocol.TextDocumentIdentifier{URI: params.TextDocument.URI},
-	})
+	return nil, nil
 }
 func (s *Server) ShowDocument(ctx context.Context, params *protocol.ShowDocumentParams) (*protocol.ShowDocumentResult, error) {
 	return nil, nil

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2655,11 +2655,6 @@ func TestFormatter_RestartAfterCrash(t *testing.T) {
 }
 
 func TestFormatter_WillSaveWaitUntil(t *testing.T) {
-	_, err := exec.LookPath("mix")
-	if err != nil {
-		t.Skip("mix not available in PATH")
-	}
-
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
@@ -2679,11 +2674,8 @@ func TestFormatter_WillSaveWaitUntil(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if edits == nil {
-		t.Fatal("expected WillSaveWaitUntil to return formatting edits")
-	}
-	if !strings.Contains(edits[0].NewText, "defmodule Test do") {
-		t.Errorf("expected formatted output, got: %s", edits[0].NewText)
+	if edits != nil {
+		t.Fatal("expected WillSaveWaitUntil to return no edits, formatting should only happen via textDocument/formatting")
 	}
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -672,26 +672,15 @@ func ContainsDo(trimmed string) bool {
 	return trimmed == "do" || strings.HasSuffix(trimmed, " do") || strings.HasSuffix(trimmed, "\tdo")
 }
 
-// IsEnd returns true if the trimmed line is a block-closing "end", possibly
-// followed by closing punctuation like ")" or ",". This handles both standalone
-// "end" and "end)" as seen when fn...end is passed as an argument.
+// IsEnd returns true if the trimmed line starts with the block-closing "end"
+// keyword. It distinguishes "end" from identifiers like "endpoint" by checking
+// that the character after "end" is not an identifier character.
 func IsEnd(trimmed string) bool {
-	if trimmed == "end" {
-		return true
-	}
 	if !strings.HasPrefix(trimmed, "end") {
 		return false
 	}
-	// "end" followed only by closing punctuation/delimiters
-	for i := 3; i < len(trimmed); i++ {
-		switch trimmed[i] {
-		case ')', ']', '}', ',', ' ', '\t':
-			// valid trailing chars after end
-		default:
-			return false
-		}
-	}
-	return true
+	// "end" at end of string, or followed by a non-identifier char
+	return len(trimmed) == 3 || !isIdentChar(trimmed[3])
 }
 
 // OpensBlock returns true if the trimmed line opens a block that will be closed
@@ -705,21 +694,8 @@ func OpensBlock(trimmed string) bool {
 // It returns false when the fn...end is entirely on one line.
 // Callers should pass input through StripCommentsAndStrings first.
 func ContainsFn(code string) bool {
-	if !strings.HasPrefix(code, "fn ") && code != "fn" {
-		// Also handle fn appearing mid-expression, e.g. "x = fn arg ->"
-		idx := strings.Index(code, " fn ")
-		if idx < 0 {
-			// Check for patterns like "Enum.map(list, fn arg ->" or "(fn arg ->"
-			for _, prefix := range []string{"(fn ", ",fn ", ", fn "} {
-				if i := strings.Index(code, prefix); i >= 0 {
-					idx = i + len(prefix) - len("fn ")
-					break
-				}
-			}
-		}
-		if idx < 0 {
-			return false
-		}
+	if !containsFnKeyword(code) {
+		return false
 	}
 	// Must not have a matching end on the same line (inline fn...end).
 	if idx := strings.LastIndex(code, " end"); idx >= 0 {
@@ -728,6 +704,34 @@ func ContainsFn(code string) bool {
 		}
 	}
 	return true
+}
+
+// containsFnKeyword returns true if code contains "fn" as a standalone keyword,
+// not part of a longer identifier. The character before "fn" must be a
+// non-identifier char (or start of string), and the character after must also
+// be a non-identifier char (or end of string).
+func containsFnKeyword(code string) bool {
+	for i := 0; i <= len(code)-2; i++ {
+		if code[i] != 'f' || code[i+1] != 'n' {
+			continue
+		}
+		// Check character before: must be start of string or non-identifier.
+		// ':' before means it's an atom (:fn), not the keyword.
+		if i > 0 && (isIdentChar(code[i-1]) || code[i-1] == ':') {
+			continue
+		}
+		// Check character after: must be end of string or non-identifier.
+		// ':' after means it's a keyword key (fn: value), not the keyword.
+		if i+2 < len(code) && (isIdentChar(code[i+2]) || code[i+2] == ':') {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func isIdentChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
 }
 
 // findDelegateTo searches the current line and up to 5 subsequent lines for a to: target,

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -80,7 +80,7 @@ func ParseFile(path string) ([]Definition, []Reference, error) {
 func ParseText(path, text string) ([]Definition, []Reference, error) {
 	type moduleFrame struct {
 		name           string
-		indent         int
+		depth          int // do..end/fn..end nesting depth when this module was opened
 		savedAliases   map[string]string
 		savedInjectors map[string]bool
 	}
@@ -89,6 +89,7 @@ func ParseText(path, text string) ([]Definition, []Reference, error) {
 	var defs []Definition
 	var refs []Reference
 	var moduleStack []moduleFrame
+	depth := 0
 	aliases := map[string]string{} // short name -> full module
 	injectors := map[string]bool{} // modules from use/import that inject bare functions
 	inHeredoc := false
@@ -96,29 +97,9 @@ func ParseText(path, text string) ([]Definition, []Reference, error) {
 	for lineIdx, line := range lines {
 		lineNum := lineIdx + 1
 
-		// Heredoc tracking — handle both """ and '''
-		if strings.IndexByte(line, '"') >= 0 {
-			quoteCount := strings.Count(line, `"""`)
-			if quoteCount > 0 {
-				if quoteCount >= 2 {
-					continue
-				}
-				inHeredoc = !inHeredoc
-				continue
-			}
-		}
-		if strings.IndexByte(line, '\'') >= 0 {
-			quoteCount := strings.Count(line, `'''`)
-			if quoteCount > 0 {
-				if quoteCount >= 2 {
-					continue
-				}
-				inHeredoc = !inHeredoc
-				continue
-			}
-		}
-
-		if inHeredoc {
+		var skip bool
+		inHeredoc, skip = CheckHeredoc(line, inHeredoc)
+		if skip {
 			continue
 		}
 
@@ -133,18 +114,30 @@ func ParseText(path, text string) ([]Definition, []Reference, error) {
 		first := line[trimStart]
 		rest := line[trimStart:] // line content from first non-whitespace char
 
+		strippedRest := strings.TrimRight(StripCommentsAndStrings(rest), " \t\r")
+
 		// 'e' — check for "end" to pop module stack; otherwise fall through
 		if first == 'e' {
-			if len(moduleStack) > 0 && strings.TrimRight(rest, " \t\r") == "end" {
-				if moduleStack[len(moduleStack)-1].indent == trimStart {
+			if IsEnd(strippedRest) {
+				if len(moduleStack) > 0 && moduleStack[len(moduleStack)-1].depth == depth {
 					frame := moduleStack[len(moduleStack)-1]
 					moduleStack = moduleStack[:len(moduleStack)-1]
 					aliases = frame.savedAliases
 					injectors = frame.savedInjectors
 				}
+				depth--
+				if depth < 0 {
+					depth = 0
+				}
 				continue
 			}
 			// Not "end" — may be a bare macro call like "embedded_schema do"
+		}
+
+		// Track block-opening keywords (do..end and fn..end) for depth counting.
+		// This covers defmodule/def/defp/case/cond/fn/etc. — any construct closed by "end".
+		if OpensBlock(strippedRest) {
+			depth++
 		}
 
 		currentModule := ""
@@ -342,7 +335,7 @@ func ParseText(path, text string) ([]Definition, []Reference, error) {
 					name = currentModule + "." + name
 				}
 				currentModule = name
-				moduleStack = append(moduleStack, moduleFrame{name: currentModule, indent: trimStart, savedAliases: copyMap(aliases), savedInjectors: copyBoolMap(injectors)})
+				moduleStack = append(moduleStack, moduleFrame{name: currentModule, depth: depth, savedAliases: copyMap(aliases), savedInjectors: copyBoolMap(injectors)})
 				defs = append(defs, Definition{
 					Module:   currentModule,
 					Line:     lineNum,
@@ -357,7 +350,7 @@ func ParseText(path, text string) ([]Definition, []Reference, error) {
 					name = currentModule + "." + name
 				}
 				currentModule = name
-				moduleStack = append(moduleStack, moduleFrame{name: currentModule, indent: trimStart, savedAliases: copyMap(aliases), savedInjectors: copyBoolMap(injectors)})
+				moduleStack = append(moduleStack, moduleFrame{name: currentModule, depth: depth, savedAliases: copyMap(aliases), savedInjectors: copyBoolMap(injectors)})
 				defs = append(defs, Definition{
 					Module:   currentModule,
 					Line:     lineNum,
@@ -372,7 +365,7 @@ func ParseText(path, text string) ([]Definition, []Reference, error) {
 					name = currentModule + "." + name
 				}
 				currentModule = name
-				moduleStack = append(moduleStack, moduleFrame{name: currentModule, indent: trimStart, savedAliases: copyMap(aliases), savedInjectors: copyBoolMap(injectors)})
+				moduleStack = append(moduleStack, moduleFrame{name: currentModule, depth: depth, savedAliases: copyMap(aliases), savedInjectors: copyBoolMap(injectors)})
 				defs = append(defs, Definition{
 					Module:   currentModule,
 					Line:     lineNum,
@@ -477,7 +470,7 @@ func ParseText(path, text string) ([]Definition, []Reference, error) {
 			continue
 		}
 		{
-			codeLine := stripCommentsAndStrings(line)
+			codeLine := StripCommentsAndStrings(line)
 
 			// Module.function calls (including type refs like User.t())
 			for _, match := range moduleCallRe.FindAllStringSubmatch(codeLine, -1) {
@@ -650,10 +643,91 @@ func ScanFuncDef(rest string) (string, string, bool) {
 	return "", "", false
 }
 
+// CheckHeredoc updates the inHeredoc state for a given line. Returns the new
+// inHeredoc state and whether this line is a heredoc boundary or content that
+// should be skipped by callers doing line-by-line analysis.
+func CheckHeredoc(line string, inHeredoc bool) (newState bool, skip bool) {
+	if strings.IndexByte(line, '"') >= 0 {
+		if c := strings.Count(line, `"""`); c > 0 {
+			if c < 2 {
+				inHeredoc = !inHeredoc
+			}
+			return inHeredoc, true
+		}
+	}
+	if strings.IndexByte(line, '\'') >= 0 {
+		if c := strings.Count(line, `'''`); c > 0 {
+			if c < 2 {
+				inHeredoc = !inHeredoc
+			}
+			return inHeredoc, true
+		}
+	}
+	return inHeredoc, inHeredoc
+}
+
 // ContainsDo returns true if the trimmed line ends with a block-opening " do"
 // (not an inline "do:" keyword argument).
 func ContainsDo(trimmed string) bool {
-	return strings.HasSuffix(trimmed, " do") || strings.HasSuffix(trimmed, "\tdo")
+	return trimmed == "do" || strings.HasSuffix(trimmed, " do") || strings.HasSuffix(trimmed, "\tdo")
+}
+
+// IsEnd returns true if the trimmed line is a block-closing "end", possibly
+// followed by closing punctuation like ")" or ",". This handles both standalone
+// "end" and "end)" as seen when fn...end is passed as an argument.
+func IsEnd(trimmed string) bool {
+	if trimmed == "end" {
+		return true
+	}
+	if !strings.HasPrefix(trimmed, "end") {
+		return false
+	}
+	// "end" followed only by closing punctuation/delimiters
+	for i := 3; i < len(trimmed); i++ {
+		switch trimmed[i] {
+		case ')', ']', '}', ',', ' ', '\t':
+			// valid trailing chars after end
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// OpensBlock returns true if the trimmed line opens a block that will be closed
+// by a matching "end". This covers both do..end blocks and fn..end blocks.
+func OpensBlock(trimmed string) bool {
+	return ContainsDo(trimmed) || ContainsFn(trimmed)
+}
+
+// ContainsFn returns true if the line opens an anonymous function block
+// (fn ... -> on its own line) that will be closed by a matching "end".
+// It returns false when the fn...end is entirely on one line.
+// Callers should pass input through StripCommentsAndStrings first.
+func ContainsFn(code string) bool {
+	if !strings.HasPrefix(code, "fn ") && code != "fn" {
+		// Also handle fn appearing mid-expression, e.g. "x = fn arg ->"
+		idx := strings.Index(code, " fn ")
+		if idx < 0 {
+			// Check for patterns like "Enum.map(list, fn arg ->" or "(fn arg ->"
+			for _, prefix := range []string{"(fn ", ",fn ", ", fn "} {
+				if i := strings.Index(code, prefix); i >= 0 {
+					idx = i + len(prefix) - len("fn ")
+					break
+				}
+			}
+		}
+		if idx < 0 {
+			return false
+		}
+	}
+	// Must not have a matching end on the same line (inline fn...end).
+	if idx := strings.LastIndex(code, " end"); idx >= 0 {
+		if IsEnd(strings.TrimSpace(code[idx:])) {
+			return false
+		}
+	}
+	return true
 }
 
 // findDelegateTo searches the current line and up to 5 subsequent lines for a to: target,
@@ -958,10 +1032,10 @@ func hasUppercase(s string) bool {
 	return false
 }
 
-// stripCommentsAndStrings removes inline comments and replaces the content
+// StripCommentsAndStrings removes inline comments and replaces the content
 // of string literals and sigils with spaces so that regex-based extraction
 // doesn't produce false-positive references from comments, strings, or sigils.
-func stripCommentsAndStrings(line string) string {
+func StripCommentsAndStrings(line string) string {
 	// Fast path: skip allocation if line has no strings, comments, or sigils
 	if !strings.ContainsAny(line, "\"'#~") {
 		return line

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1220,6 +1220,41 @@ end
 	}
 }
 
+func TestParseFile_FnEndMisindentedDoesNotPopModule(t *testing.T) {
+	// Regression: when fn...end is misformatted so the end aligns with defmodule,
+	// indent-matching would incorrectly pop the module. Depth-counting handles this.
+	path := writeTempFile(t, `defmodule MyModule do
+  def build(items) do
+    handler = fn item ->
+      item
+end
+  end
+
+  def next(x) do
+    x + 1
+  end
+end
+`)
+
+	defs, _, err := ParseFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	funcs := map[string]string{}
+	for _, d := range defs {
+		if d.Function != "" {
+			funcs[d.Function] = d.Module
+		}
+	}
+
+	for _, name := range []string{"build", "next"} {
+		if funcs[name] != "MyModule" {
+			t.Errorf("%s should belong to MyModule, got %q (all funcs: %v)", name, funcs[name], funcs)
+		}
+	}
+}
+
 func TestParseFile_FnEndWithTrailingParen(t *testing.T) {
 	path := writeTempFile(t, `defmodule MyModule do
   def process(enumerable) do

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1255,6 +1255,44 @@ end
 	}
 }
 
+func TestParseFile_TrailingFnDoesNotPopModule(t *testing.T) {
+	// Regression: "handler = fn" at end of line was not detected as a block
+	// opener because ContainsFn required a space after "fn".
+	path := writeTempFile(t, `defmodule MyModule do
+  def build do
+    handler = fn
+      :ok -> true
+      :error -> false
+    end
+
+    handler
+  end
+
+  def next(x) do
+    x + 1
+  end
+end
+`)
+
+	defs, _, err := ParseFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	funcs := map[string]string{}
+	for _, d := range defs {
+		if d.Function != "" {
+			funcs[d.Function] = d.Module
+		}
+	}
+
+	for _, name := range []string{"build", "next"} {
+		if funcs[name] != "MyModule" {
+			t.Errorf("%s should belong to MyModule, got %q (all funcs: %v)", name, funcs[name], funcs)
+		}
+	}
+}
+
 func TestParseFile_FnEndWithTrailingParen(t *testing.T) {
 	path := writeTempFile(t, `defmodule MyModule do
   def process(enumerable) do


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core Elixir parsing used for alias scoping, reference extraction, and folding ranges, so subtle depth-detection regressions could affect navigation features. Disabling `WillSaveWaitUntil` reduces behavior on save but is straightforward and covered by updated tests.
> 
> **Overview**
> Fixes Elixir scope/depth tracking by switching module-stack popping from indent-based heuristics to **block depth counting** that understands both `do..end` and multi-line `fn..end`, while ignoring false `do/end` tokens in comments, strings, and heredocs via new helpers like `CheckHeredoc`, `StripCommentsAndStrings`, `IsEnd`, and `OpensBlock`.
> 
> Updates LSP features to use the same stripped-token logic for alias scoping (`ExtractAliasesInScope`) and folding range detection, and **disables `WillSaveWaitUntil` formatting** (capability flag off and handler returns nil), leaving formatting to `textDocument/formatting`. Adds regression tests for `fn` blocks, heredocs, and trailing `fn` patterns, and updates the server test to expect no edits on will-save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a599cf7317dc38fa95841b7bb8562dcd534b08b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->