### PR TITLE
Fix formatter _build dir lookup when inside an umbrella app

### DIFF
--- a/internal/lsp/formatter.go
+++ b/internal/lsp/formatter.go
@@ -172,7 +172,7 @@ func (s *Server) startFormatterProcess(mixRoot, formatterExs string) (*formatter
 	}
 
 	elixirBin := filepath.Join(filepath.Dir(s.mixBin), "elixir")
-	cmd := exec.Command(elixirBin, scriptPath, mixRoot, formatterExs)
+	cmd := exec.Command(elixirBin, scriptPath, mixRoot, formatterExs, s.projectRoot)
 	cmd.Dir = mixRoot
 
 	stdin, err := cmd.StdinPipe()

--- a/internal/lsp/formatter_server.exs
+++ b/internal/lsp/formatter_server.exs
@@ -18,19 +18,45 @@
 # corrupting our binary protocol framing.
 :io.setopts(:standard_io, encoding: :latin1)
 
-[mix_root | rest] = System.argv()
-formatter_exs_path = List.first(rest)
+[mix_root, formatter_exs_path, project_root_arg] = System.argv()
+
+# In umbrella apps, _build and deps live at the umbrella root, not in
+# individual app directories. Walk up from mix_root (bounded by the project
+# root) to find the nearest ancestor that contains a _build directory.
+expanded_mix_root = Path.expand(mix_root)
+expanded_boundary = Path.expand(project_root_arg)
+
+# If there are really umbrella apps with a distance greater than 20 to the root
+# we can update this (or maybe make it configurable), but 20 seems like a sane
+# limit.
+project_root =
+  Enum.reduce_while(1..20, expanded_mix_root, fn _, dir ->
+    cond do
+      File.dir?(Path.join(dir, "_build")) ->
+        {:halt, dir}
+      dir == expanded_boundary ->
+        {:halt, expanded_mix_root}
+      true ->
+        parent = Path.dirname(dir)
+
+        if parent == dir do
+          {:halt, expanded_mix_root}
+        else
+          {:cont, parent}
+        end
+    end
+  end)
 
 # Add the project's compiled deps to the code path so plugins are available
 # without needing Mix.install
-mix_root
+project_root
 |> Path.join("_build/dev/lib/*/ebin")
 |> Path.wildcard()
 |> Enum.each(&Code.prepend_path/1)
 
 # Read .formatter.exs
 raw_opts =
-  if formatter_exs_path && File.regular?(formatter_exs_path) do
+  if File.regular?(formatter_exs_path) do
     {result, _} = Code.eval_file(formatter_exs_path)
     if is_list(result), do: result, else: []
   else
@@ -46,7 +72,7 @@ import_deps_locals =
   raw_opts
   |> Keyword.get(:import_deps, [])
   |> Enum.flat_map(fn dep ->
-    dep_formatter = Path.join([mix_root, "deps", to_string(dep), ".formatter.exs"])
+    dep_formatter = Path.join([project_root, "deps", to_string(dep), ".formatter.exs"])
 
     if File.regular?(dep_formatter) do
       {dep_opts, _} = Code.eval_file(dep_formatter)

--- a/internal/lsp/formatter_test.go
+++ b/internal/lsp/formatter_test.go
@@ -268,6 +268,84 @@ end
 	}
 }
 
+func TestFormatterServer_UmbrellaStylerPlugin(t *testing.T) {
+	if _, err := exec.LookPath("mix"); err != nil {
+		t.Skip("mix not available in PATH")
+	}
+
+	// Ensure the Styler fixture is compiled so we have beam files to reuse
+	monorepo := fixtureMonorepoPath(t)
+	stylerFixture := filepath.Join(monorepo, "apps", "app_with_styler")
+	ensureFixtureDeps(t, stylerFixture)
+
+	// Create an umbrella-like temp directory where _build is only at the
+	// root, not in the child app — this is how real umbrella apps work.
+	umbrellaRoot := t.TempDir()
+	childApp := filepath.Join(umbrellaRoot, "apps", "child_app")
+	if err := os.MkdirAll(filepath.Join(childApp, "lib"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Symlink _build from the existing fixture to the umbrella root
+	if err := os.Symlink(
+		filepath.Join(stylerFixture, "_build"),
+		filepath.Join(umbrellaRoot, "_build"),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a minimal mix.exs so findMixRoot stops at the child app
+	if err := os.WriteFile(
+		filepath.Join(childApp, "mix.exs"),
+		[]byte("defmodule ChildApp.MixProject do\n  use Mix.Project\n  def project, do: [app: :child_app, version: \"0.1.0\"]\nend\n"),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write .formatter.exs with Styler plugin
+	if err := os.WriteFile(
+		filepath.Join(childApp, ".formatter.exs"),
+		[]byte("[plugins: [Styler], inputs: [\"{lib,test}/**/*.{ex,exs}\"]]\n"),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up server with the umbrella root as projectRoot
+	storeDir := t.TempDir()
+	s, err := store.Open(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+	server := NewServer(s, umbrellaRoot)
+	if p, err := exec.LookPath("mix"); err == nil {
+		server.mixBin = p
+	}
+
+	unformatted := "defmodule Test do\n  def hello(x) do\n    x |> to_string()\n  end\nend\n"
+	filePath := filepath.Join(childApp, "lib", "test.ex")
+	docURI := string(uri.File(filePath))
+	server.docs.Set(docURI, unformatted)
+
+	edits, err := server.Formatting(context.Background(), &protocol.DocumentFormattingParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI(docURI)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edits == nil {
+		t.Fatal("expected formatting edits from Styler in umbrella child app, got nil")
+	}
+	if !strings.Contains(edits[0].NewText, "to_string(x)") {
+		t.Errorf("expected Styler to rewrite pipe in umbrella child app, got:\n%s", edits[0].NewText)
+	}
+	if strings.Contains(edits[0].NewText, "|>") {
+		t.Errorf("expected Styler to remove single pipe in umbrella child app, got:\n%s", edits[0].NewText)
+	}
+}
+
 func TestComputeMinimalEdits(t *testing.T) {
 	t.Run("identical text returns nil", func(t *testing.T) {
 		edits := computeMinimalEdits("hello\nworld\n", "hello\nworld\n")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the persistent formatter locates `_build` and `deps` and how arguments are passed into the Elixir formatter script, which can affect formatting/plugin loading across projects (especially umbrella layouts). Includes a new integration-style test covering symlinked `_build` behavior, reducing regression risk but still touching core formatting flow.
> 
> **Overview**
> Fixes persistent formatter behavior inside *umbrella* Elixir apps by teaching `formatter_server.exs` to walk up from `mix_root` (bounded by `projectRoot`) to find the correct ancestor containing `_build`, and then using that `project_root` for plugin code paths and `import_deps` `.formatter.exs` resolution.
> 
> Updates the Go launcher (`formatter.go`) to pass `projectRoot` into the formatter script, and adds `TestFormatterServer_UmbrellaStylerPlugin` to verify Styler plugins load and apply when `_build` exists only at the umbrella root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862848180a5e2ff4962f99231ca713938b2d1dbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->