### PR TITLE
Release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.5.3] - 2026-04-09
+
+### Added
+
+- **Open-source release** — Dexter is now available under the MIT license on GitHub, with updated install scripts for mise and asdf
+
+### Fixed
+
+- **Aliases injected via `use`** — `use` macros that inject `alias` declarations (e.g. `alias MyApp.Repo` inside `__using__`) now propagate those aliases to the consumer module, so go-to-definition, hover, completions, references, rename, signature help, and all other LSP features correctly resolve the aliased modules; also follows transitive `use` chains and helper `quote do` blocks
+- **Module depth tracking** — module nesting depth is now tracked by counting `do..end` and `fn..end` blocks instead of relying on indentation, fixing incorrect module scope attribution when anonymous functions or other nested blocks were present; heredoc content and string literals are now properly excluded from block detection
+- **Formatter `_build` lookup in umbrella apps** — the persistent formatter process now walks up from the app's mix root to the umbrella root to find `_build` and `deps`, so formatter plugins and `import_deps` resolve correctly in umbrella projects
+- **Folding ranges** — folding range detection now strips strings and comments before checking for block boundaries, preventing false ranges from string content like `"foo do"`
+
 ## [0.5.2] - 2026-04-07
 
 ### Added

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,8 @@
 package version
 
-const Version = "0.5.2"
+const Version = "0.5.3"
 
 // IndexVersion is incremented whenever the index schema or parser changes in a
 // way that requires a full rebuild. Bump this alongside Version when releasing
 // a change that makes existing indexes stale.
-const IndexVersion = 8
+const IndexVersion = 9


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version/changelog), with the main impact being a forced index rebuild due to `IndexVersion` bump.
> 
> **Overview**
> Updates the project for the `0.5.3` release by bumping `internal/version/version.go` to `Version = 0.5.3` and incrementing `IndexVersion` to `9` (triggering a full index rebuild).
> 
> Adds `0.5.3` release notes to `CHANGELOG.md`, highlighting the open-source MIT release and multiple LSP/formatter/folding fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5af2d50174ee3605299d2887fbe59a8fb251356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->