### PR TITLE
Update readme headline performance stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A fast, full-featured Elixir LSP optimized for large Elixir codebases.
 
 ## Features
 
-- **Fast indexing** — cold index completes in ~11s on a 57k-file Elixir monorepo, ~93ms on Oban, ~90ms on the Elixir standard library (measured on an M1 MacBook Pro). After your first index, incremental indexing makes sure that you never have to reindex the whole codebase again.
+- **Fast indexing** — cold index completes in ~11s on a 57k-file Elixir monorepo, ~100ms on Oban, ~300ms on the Elixir standard library (measured on an M1 MacBook Pro). After your first index, incremental indexing makes sure that you never have to reindex the whole codebase again.
 - **Go-to-definition** — jump to any module, function, type, or variable definition. Resolves aliases, imports, `defdelegate` chains, `use` injections, and the Elixir stdlib. Handles all definition forms: `def`, `defp`, `defmacro`, `defprotocol`, `defimpl`, `defstruct`, and more.
 - **Go-to-references** — find all usages of a function or module across the codebase, including through `import`, `use` chains, and `defdelegate`.
 - **Hover documentation** — `@doc`, `@moduledoc`, `@typedoc`, and `@spec` annotations rendered as Markdown when you hover over a symbol.


### PR DESCRIPTION
Profiled the latest on Oban and Elixir repos using the latest version and it's now a little bit slower. I'd guess because we've added some richer parsing and better reference handling, so we're picking up more data than before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating stated indexing timings; no runtime behavior is affected.
> 
> **Overview**
> Updates `README.md` feature headline performance stats for **fast indexing** to reflect newly measured timings (notably increasing the reported Oban and stdlib cold index times).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 029a491ecb0187ff4a3622ca6dd3eefadb8e7b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->