### PR TITLE
Move index database into .dexter/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dexter
 
 # Database
 *.db
+.dexter/
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A fast, full-featured Elixir LSP optimized for large Elixir codebases.
   - [Variables](#variables)
 - [Lightning-fast formatting](#lightning-fast-formatting)
 - [LSP options](#lsp-options)
-- [Index database location (.dexter.db)](#index-database-location-dexterdb)
+- [Index database location (.dexter/)](#index-database-location-dexter)
 - [Debugging](#debugging)
 - [Development (building from source)](#development-building-from-source)
 - [Releasing](#releasing)
@@ -101,8 +101,8 @@ mise plugin add dexter https://github.com/remoteoss/dexter.git && mise use -g de
 # or, with asdf:
 # asdf plugin add dexter https://github.com/remoteoss/dexter.git && asdf install dexter latest && asdf global dexter latest
 
-# 3. Add .dexter.db to your .gitignore
-echo ".dexter.db*" >> .gitignore
+# 3. Add .dexter/ to your .gitignore
+echo ".dexter/" >> .gitignore
 
 # 4. Configure your editor (see below)
 # The LSP server auto-builds the index on first startup — no need to run dexter init manually.
@@ -155,7 +155,7 @@ Add to your LSP configuration (e.g., `after/plugin/lsp.lua`):
 ```lua
 vim.lsp.config('dexter', {
   cmd = { 'dexter', 'lsp' },
-  root_markers = { '.dexter.db', '.git', 'mix.exs' },
+  root_markers = { '.dexter/dexter.db', '.dexter.db', '.git', 'mix.exs' },
   filetypes = { 'elixir', 'eelixir', 'heex' },
   init_options = {
     followDelegates = true,  -- jump through defdelegate to the target function
@@ -187,7 +187,7 @@ configs.dexter = {
   default_config = {
     cmd = { "dexter", "lsp" }, -- update this if you don't have Dexter in your PATH
     filetypes = { "elixir", "eelixir", "heex" },
-    root_dir = lspconfig.util.root_pattern(".dexter.db", "mix.exs", ".git"),
+    root_dir = lspconfig.util.root_pattern(".dexter/dexter.db", ".dexter.db", "mix.exs", ".git"),
   },
 }
 
@@ -379,11 +379,13 @@ Dexter reads `initializationOptions` from your editor configuration:
 - **`stdlibPath`** (string): override the Elixir stdlib directory to index. Defaults to auto-detection; use this if your install is non-standard.
 - **`debug`** (boolean, default: `false`): enable verbose logging to stderr. Logs timing and resolution details for every definition, hover, references, and rename request. Can also be enabled via the `DEXTER_DEBUG=true` environment variable.
 
-## Index database location (.dexter.db)
+## Index database location (.dexter/)
 
-Dexter creates `.dexter.db` at the root of your project when you start the LSP for the first time. But if you prefer, you can run `dexter init` yourself in the root of your project. Where you place it determines what gets indexed.
+Dexter creates `.dexter/dexter.db` at the root of your project when you start the LSP for the first time. But if you prefer, you can run `dexter init` yourself in the root of your project. Where you place it determines what gets indexed.
 
-When the LSP server starts, it walks up from the project root looking for `.dexter.db`, preferring `.git` as the anchor point. This means if you initialised from the monorepo root, the server will find the right database even when Neovim's `rootUri` points to a sub-app (e.g. because `mix.exs` is there).
+When the LSP server starts, it walks up from the project root looking for `.dexter/dexter.db`, preferring `.git` as the anchor point. This means if you initialised from the monorepo root, the server will find the right database even when Neovim's `rootUri` points to a sub-app (e.g. because `mix.exs` is there).
+
+If you're upgrading from a pre-`.dexter/` version of dexter, any existing `.dexter.db` file at your project root will be automatically deleted and rebuilt into the new `.dexter/` folder on the next `dexter init` or LSP startup. Update your `.gitignore` to use `.dexter/` in place of `.dexter.db*`.
 
 **Monorepo root (recommended if using an Elixir monorepo or umbrella structure)** — Put the index at the root of your repository, next to `.git`. This indexes everything: all apps, all shared libraries, and all deps. Go-to-definition works across the entire codebase.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -146,25 +146,11 @@ func findProjectRoot(path string) string {
 	if !info.IsDir() {
 		path = filepath.Dir(path)
 	}
-
-	for _, marker := range []string{".dexter.db", ".git", "mix.exs"} {
-		dir := path
-		for {
-			if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
-				return dir
-			}
-			parent := filepath.Dir(dir)
-			if parent == dir {
-				break
-			}
-			dir = parent
-		}
-	}
-	return path
+	return store.FindProjectRoot(path, "mix.exs")
 }
 
 func cmdInit(projectRoot string, force bool, profile bool) {
-	dbPath := filepath.Join(projectRoot, ".dexter.db")
+	dbPath := store.DBPath(projectRoot)
 	if _, err := os.Stat(dbPath); err == nil {
 		if !force {
 			fmt.Fprintf(os.Stderr, "Index already exists at %s\n", dbPath)

--- a/integration_test.go
+++ b/integration_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/remoteoss/dexter/internal/store"
 )
 
 // buildDexter builds the binary once for all integration tests
@@ -459,8 +461,8 @@ end`,
 		t.Errorf("expected lookup to find Foo via .git root db, got: %s", out)
 	}
 
-	if _, err := os.Stat(filepath.Join(subapp, ".dexter.db")); err == nil {
-		t.Error("should not have created a second .dexter.db in the subapp")
+	if _, err := os.Stat(filepath.Join(subapp, ".dexter", "dexter.db")); err == nil {
+		t.Error("should not have created a second .dexter/dexter.db in the subapp")
 	}
 }
 
@@ -505,7 +507,7 @@ func TestIntegration_CorruptDBRecovery(t *testing.T) {
 	runDexter(t, binary, root, "init", root)
 
 	// Corrupt the DB with garbage bytes
-	dbPath := filepath.Join(root, ".dexter.db")
+	dbPath := store.DBPath(root)
 	if err := os.WriteFile(dbPath, []byte("not a sqlite database"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -520,5 +522,45 @@ func TestIntegration_CorruptDBRecovery(t *testing.T) {
 	out2 := runDexter(t, binary, root, "lookup", "MyApp.Repo", "get")
 	if !strings.Contains(out2, "repo.ex:2") {
 		t.Errorf("expected lookup to work after corrupt DB recovery, got: %s", out2)
+	}
+}
+
+// TestIntegration_LegacyMigration simulates an upgrade path: a project with
+// the pre-.dexter/ folder layout (legacy .dexter.db file and its WAL
+// siblings at the root) is migrated automatically on the next dexter
+// invocation. The legacy files should be deleted and a fresh index built
+// at .dexter/dexter.db.
+func TestIntegration_LegacyMigration(t *testing.T) {
+	binary := buildDexter(t)
+	root := scaffoldProject(t)
+
+	// Seed the legacy layout.
+	legacy := filepath.Join(root, ".dexter.db")
+	for _, f := range []string{legacy, legacy + "-shm", legacy + "-wal"} {
+		if err := os.WriteFile(f, []byte("legacy placeholder"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Run init — migration runs inside store.Open.
+	runDexter(t, binary, root, "init", root)
+
+	// Legacy files should be gone.
+	for _, f := range []string{legacy, legacy + "-shm", legacy + "-wal"} {
+		if _, err := os.Stat(f); !os.IsNotExist(err) {
+			t.Errorf("legacy file %s still exists after migration", f)
+		}
+	}
+
+	// New DB should exist and be functional.
+	newDB := filepath.Join(root, ".dexter", "dexter.db")
+	if _, err := os.Stat(newDB); err != nil {
+		t.Errorf("new DB not created: %v", err)
+	}
+
+	// Lookups should work against the migrated index.
+	out := runDexter(t, binary, root, "lookup", "MyApp.Repo")
+	if !strings.Contains(out, "repo.ex:1") {
+		t.Errorf("expected lookup to work after migration, got: %s", out)
 	}
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -286,16 +286,20 @@ func (s *Server) notifyOTPMismatch(stderr string) {
 // === LSP Lifecycle ===
 
 func (s *Server) Initialize(ctx context.Context, params *protocol.InitializeParams) (*protocol.InitializeResult, error) {
+	// Note: unlike cmd/main.go, the LSP deliberately does NOT pass "mix.exs"
+	// to store.FindProjectRoot. In a monorepo we want to anchor on
+	// .dexter/dexter.db or .git so the whole repo is indexed, not the first
+	// nested Mix app we encounter.
 	if !s.explicitRoot {
 		if len(params.WorkspaceFolders) > 0 {
 			root := uriToPath(protocol.DocumentURI(params.WorkspaceFolders[0].URI))
 			if root != "" {
-				s.projectRoot = findDexterRoot(root)
+				s.projectRoot = store.FindProjectRoot(root)
 			}
 		} else if params.RootURI != "" { //nolint:staticcheck // RootURI is deprecated but Neovim still sends it
 			root := uriToPath(params.RootURI) //nolint:staticcheck
 			if root != "" {
-				s.projectRoot = findDexterRoot(root)
+				s.projectRoot = store.FindProjectRoot(root)
 			}
 		}
 	}
@@ -730,25 +734,6 @@ func nthLine(text string, n int) (string, bool) {
 		return text[start:], true
 	}
 	return text[start : start+end], true
-}
-
-// findDexterRoot walks up from the given path looking for .dexter.db first,
-// then .git (monorepo root), falling back to the original path.
-func findDexterRoot(path string) string {
-	for _, marker := range []string{".dexter.db", ".git"} {
-		dir := path
-		for {
-			if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
-				return dir
-			}
-			parent := filepath.Dir(dir)
-			if parent == dir {
-				break
-			}
-			dir = parent
-		}
-	}
-	return path
 }
 
 // findMixRoot walks up from dir looking for the nearest mix.exs.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -70,7 +70,14 @@ func FindProjectRoot(path string, extraMarkers ...string) string {
 }
 
 func Open(projectRoot string) (*Store, error) {
-	dbPath := filepath.Join(projectRoot, ".dexter.db")
+	if err := migrateLegacyLayout(projectRoot); err != nil {
+		return nil, fmt.Errorf("migrate legacy layout: %w", err)
+	}
+	if err := os.MkdirAll(DBDir(projectRoot), 0o755); err != nil {
+		return nil, fmt.Errorf("create dexter dir: %w", err)
+	}
+
+	dbPath := DBPath(projectRoot)
 	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000&_foreign_keys=ON")
 	if err != nil {
 		return nil, err
@@ -83,6 +90,28 @@ func Open(projectRoot string) (*Store, error) {
 	}
 
 	return &Store{db: db}, nil
+}
+
+// migrateLegacyLayout deletes any pre-.dexter/ folder artifacts so that a
+// fresh database will be built at the new location on the next Open. The
+// index is a derived cache, so deletion (rather than move) is safe and
+// avoids WAL/SHM consistency edge cases.
+//
+// Returns nil when there is nothing to migrate.
+func migrateLegacyLayout(projectRoot string) error {
+	legacy := LegacyDBPath(projectRoot)
+	if _, err := os.Stat(legacy); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat legacy db %s: %w", legacy, err)
+	}
+	for _, f := range []string{legacy, legacy + "-shm", legacy + "-wal"} {
+		if err := os.Remove(f); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove %s: %w", f, err)
+		}
+	}
+	return nil
 }
 
 func (s *Store) Close() error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,6 +34,41 @@ func LegacyDBPath(projectRoot string) string {
 	return filepath.Join(projectRoot, ".dexter.db")
 }
 
+// FindProjectRoot walks up from path looking for known dexter/project
+// markers. The default markers (in priority order) are:
+//
+//  1. .dexter/dexter.db — the current database layout
+//  2. .dexter.db         — the legacy layout (pre-.dexter/ folder)
+//  3. .git               — repository root fallback
+//
+// Additional markers can be passed via extraMarkers; they are tried after
+// the defaults, in the order given. The CLI passes "mix.exs" to fall back
+// to the nearest Mix project when no dexter/git marker is found.
+//
+// Returns the original path if no marker is found.
+func FindProjectRoot(path string, extraMarkers ...string) string {
+	markers := append([]string{
+		filepath.Join(".dexter", "dexter.db"),
+		".dexter.db",
+		".git",
+	}, extraMarkers...)
+
+	for _, marker := range markers {
+		dir := path
+		for {
+			if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+				return dir
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+	return path
+}
+
 func Open(projectRoot string) (*Store, error) {
 	dbPath := filepath.Join(projectRoot, ".dexter.db")
 	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000&_foreign_keys=ON")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -16,6 +16,24 @@ type Store struct {
 	db *sql.DB
 }
 
+// DBPath returns the canonical database path for a project root:
+// <root>/.dexter/dexter.db
+func DBPath(projectRoot string) string {
+	return filepath.Join(projectRoot, ".dexter", "dexter.db")
+}
+
+// DBDir returns the directory that holds the database: <root>/.dexter
+func DBDir(projectRoot string) string {
+	return filepath.Join(projectRoot, ".dexter")
+}
+
+// LegacyDBPath returns the pre-migration database path: <root>/.dexter.db
+// Used only for detecting and deleting databases created before the
+// .dexter/ folder layout.
+func LegacyDBPath(projectRoot string) string {
+	return filepath.Join(projectRoot, ".dexter.db")
+}
+
 func Open(projectRoot string) (*Store, error) {
 	dbPath := filepath.Join(projectRoot, ".dexter.db")
 	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000&_foreign_keys=ON")

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/remoteoss/dexter/internal/parser"
@@ -1148,4 +1149,84 @@ end
 	if results[0].Module != "MyApp.Users" {
 		t.Errorf("expected case-sensitive match MyApp.Users first, got %s.%s", results[0].Module, results[0].Function)
 	}
+}
+
+func TestFindProjectRoot(t *testing.T) {
+	// Helper: create a directory tree inside t.TempDir() and return the root.
+	mktree := func(t *testing.T, files []string) string {
+		t.Helper()
+		root := t.TempDir()
+		for _, rel := range files {
+			full := filepath.Join(root, rel)
+			if strings.HasSuffix(rel, "/") {
+				if err := os.MkdirAll(full, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				continue
+			}
+			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(full, []byte(""), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return root
+	}
+
+	t.Run("new layout at root", func(t *testing.T) {
+		root := mktree(t, []string{".dexter/dexter.db", "apps/app/lib/foo.ex"})
+		got := FindProjectRoot(filepath.Join(root, "apps", "app"))
+		if got != root {
+			t.Errorf("got %q, want %q", got, root)
+		}
+	})
+
+	t.Run("legacy file at root", func(t *testing.T) {
+		root := mktree(t, []string{".dexter.db", "apps/app/lib/foo.ex"})
+		got := FindProjectRoot(filepath.Join(root, "apps", "app"))
+		if got != root {
+			t.Errorf("got %q, want %q", got, root)
+		}
+	})
+
+	t.Run("git fallback", func(t *testing.T) {
+		root := mktree(t, []string{".git/", "apps/app/lib/foo.ex"})
+		got := FindProjectRoot(filepath.Join(root, "apps", "app"))
+		if got != root {
+			t.Errorf("got %q, want %q", got, root)
+		}
+	})
+
+	t.Run("mix.exs extra marker", func(t *testing.T) {
+		root := mktree(t, []string{"apps/app/mix.exs", "apps/app/lib/foo.ex"})
+		start := filepath.Join(root, "apps", "app", "lib")
+		got := FindProjectRoot(start, "mix.exs")
+		want := filepath.Join(root, "apps", "app")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("no marker returns input", func(t *testing.T) {
+		root := mktree(t, []string{"lib/foo.ex"})
+		start := filepath.Join(root, "lib")
+		got := FindProjectRoot(start)
+		if got != start {
+			t.Errorf("got %q, want %q", got, start)
+		}
+	})
+
+	t.Run("new layout preferred over legacy", func(t *testing.T) {
+		// New layout at the repo root, legacy file inside a nested subdir.
+		// Walking up from the subdir must return the repo root (matching
+		// .dexter/dexter.db first), not the subdir — a reversed priority
+		// would incorrectly match the closer .dexter.db.
+		root := mktree(t, []string{".dexter/dexter.db", "apps/app/.dexter.db"})
+		cwd := filepath.Join(root, "apps", "app")
+		got := FindProjectRoot(cwd)
+		if got != root {
+			t.Errorf("got %q, want %q", got, root)
+		}
+	})
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -8,6 +8,30 @@ import (
 	"github.com/remoteoss/dexter/internal/parser"
 )
 
+func TestDBPath(t *testing.T) {
+	got := DBPath("/project/root")
+	want := filepath.Join("/project/root", ".dexter", "dexter.db")
+	if got != want {
+		t.Errorf("DBPath = %q, want %q", got, want)
+	}
+}
+
+func TestDBDir(t *testing.T) {
+	got := DBDir("/project/root")
+	want := filepath.Join("/project/root", ".dexter")
+	if got != want {
+		t.Errorf("DBDir = %q, want %q", got, want)
+	}
+}
+
+func TestLegacyDBPath(t *testing.T) {
+	got := LegacyDBPath("/project/root")
+	want := filepath.Join("/project/root", ".dexter.db")
+	if got != want {
+		t.Errorf("LegacyDBPath = %q, want %q", got, want)
+	}
+}
+
 func setupTestStore(t *testing.T) (*Store, string) {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -980,15 +980,91 @@ func TestStdlibRoot(t *testing.T) {
 
 func TestOpenCorruptedDB(t *testing.T) {
 	dir := t.TempDir()
-	dbPath := filepath.Join(dir, ".dexter.db")
 
-	if err := os.WriteFile(dbPath, []byte("this is not a sqlite database"), 0644); err != nil {
+	// Pre-create the .dexter/ folder and plant a garbage DB file in the
+	// new location so Open's migration path doesn't touch it.
+	if err := os.MkdirAll(DBDir(dir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := DBPath(dir)
+
+	if err := os.WriteFile(dbPath, []byte("this is not a sqlite database"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	_, err := Open(dir)
 	if err == nil {
 		t.Fatal("expected Open to fail on a corrupted DB file, got nil")
+	}
+}
+
+func TestOpen_CreatesDexterFolder(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if info, err := os.Stat(filepath.Join(dir, ".dexter")); err != nil || !info.IsDir() {
+		t.Errorf(".dexter/ directory was not created: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".dexter", "dexter.db")); err != nil {
+		t.Errorf(".dexter/dexter.db was not created: %v", err)
+	}
+}
+
+func TestOpen_MigratesLegacyLayout(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed a fake legacy database and its WAL siblings.
+	legacy := filepath.Join(dir, ".dexter.db")
+	legacyShm := legacy + "-shm"
+	legacyWal := legacy + "-wal"
+	for _, f := range []string{legacy, legacyShm, legacyWal} {
+		if err := os.WriteFile(f, []byte("legacy placeholder"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	for _, f := range []string{legacy, legacyShm, legacyWal} {
+		if _, err := os.Stat(f); !os.IsNotExist(err) {
+			t.Errorf("legacy file %s still exists (err=%v)", f, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".dexter", "dexter.db")); err != nil {
+		t.Errorf("new DB was not created: %v", err)
+	}
+
+	// Smoke test: the store should be functional after migration.
+	if _, err := s.db.Exec("INSERT INTO files (path, mtime) VALUES (?, ?)", "/fake.ex", 1); err != nil {
+		t.Errorf("store not functional after migration: %v", err)
+	}
+}
+
+func TestOpen_MigrationWithPartialLegacyFiles(t *testing.T) {
+	// Legacy DB present but no WAL siblings — should still migrate cleanly.
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, ".dexter.db")
+	if err := os.WriteFile(legacy, []byte("legacy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Errorf("legacy .dexter.db still exists: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Moves the SQLite index from `<project>/.dexter.db` to `<project>/.dexter/dexter.db` so the repo root stays clean and future dexter artifacts have a dedicated scratch space.
- Existing databases migrate automatically on the next `dexter init` or LSP startup: legacy `.dexter.db` and its `-shm`/`-wal` siblings are deleted and a fresh index is built in the new folder. No user action required beyond updating their own `.gitignore`.
- All path knowledge is centralized in `internal/store` via new `DBPath`, `DBDir`, `LegacyDBPath`, and `FindProjectRoot` helpers. The duplicated root-marker walks in `cmd/main.go` and `internal/lsp/server.go` are gone; the LSP call sites now have an inline comment documenting why they intentionally don't pass `mix.exs` as an extra marker.
- Editor-extension repos (`dexter-vscode`, `dexter-zed`) continue to work via their existing `mix.exs`/`.git` fallback markers and can be updated separately.

## Test plan

- [x] `make test` — all packages pass (store, lsp, integration)
- [x] `make lint` — 0 issues
- [x] New unit tests: `TestDBPath`, `TestDBDir`, `TestLegacyDBPath`, `TestFindProjectRoot` (6 subtests), `TestOpen_CreatesDexterFolder`, `TestOpen_MigratesLegacyLayout`, `TestOpen_MigrationWithPartialLegacyFiles`
- [x] New integration test: `TestIntegration_LegacyMigration` runs against the real binary, seeds legacy files, runs plain `dexter init` (no `--force`), asserts legacy deletion + new DB exists + `dexter lookup` still works
- [x] Manual smoke test: fresh `dexter init` creates `.dexter/dexter.db`; legacy `.dexter.db*` files are deleted and rebuilt on next init
- [ ] Reviewer: verify `.gitignore` recommendation lands correctly in README Quick start
- [ ] Reviewer: confirm Neovim `root_markers` still include the legacy `.dexter.db` so mid-upgrade users stay anchored


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes on-disk index location and project-root discovery for both CLI and LSP, which could break indexing/lookup if path resolution or migration logic is wrong.
> 
> **Overview**
> Moves the SQLite index from `.dexter.db` at the project root to `.dexter/dexter.db`, and updates docs and `.gitignore` guidance accordingly.
> 
> Centralizes database path + root discovery in `internal/store` via new helpers (`DBPath`, `DBDir`, `LegacyDBPath`, `FindProjectRoot`), rewiring the CLI and LSP to use them (with the LSP explicitly avoiding `mix.exs` anchoring to keep monorepo behavior).
> 
> Adds automatic cleanup-based migration: if legacy `.dexter.db`/WAL/SHM files exist, they are deleted and the index is rebuilt in `.dexter/`; unit + integration tests were updated/added to cover the new layout, migration, and root-marker behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfd09b1769fed82e6f828180833af3a885bfaf56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->