### PR TITLE
Add -race flag option on test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
           go-version-file: go.mod
       - run: go test ./...
 
+  test-race:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go test -race ./...
+
   test-integration:
     runs-on: ubuntu-latest
     container: elixir:1.19

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: build test release
+.PHONY: build test test-race release
 
 build:
 	go build -o dexter ./cmd/
 
 test:
 	go test ./...
+
+test-race:
+	go test -race ./...
 
 lint:
 	golangci-lint run ./...


### PR DESCRIPTION
Note: Apologies, I found no PR format established for the project.

This PR concerns the use of the -race flag to catch further concurrency issues when executing go code. 

**Consequences and implications**: using the -race flag causes additional overhead at runtime, meaning tests take longer. Hence why this is done **only on tests** and in a way that is separate from the default test run. Therefore, it can be disabled and enabled at will. It has no impact on release execution.

**Implementation**: 
- I propose a separate option in the [makefile ](Makefile) that is different from default test that is called test-race which runs tests with golang's -race flag.
- Additionally, the [ci ](.github/workflows/ci.yml)file has been updated to also run this -race flag, separately from the tests themselves, so that commits also report potential race conditions & other issues.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI/Makefile-only change that increases test coverage via the Go race detector, with the main impact being longer CI/test runtimes.
> 
> **Overview**
> Adds a dedicated `test-race` job to GitHub Actions CI to run `go test -race ./...` alongside the existing unit tests.
> 
> Extends the `Makefile` with a matching `test-race` target so developers can run race-detected tests locally without changing the default `make test` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d09737374f127d23b82528a739f284502d4b9be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->