### PR TITLE
Set default allocation capacities to reduce reallocations at runtime

### DIFF
--- a/internal/lsp/elixir.go
+++ b/internal/lsp/elixir.go
@@ -97,7 +97,7 @@ func ExtractFullExpression(line string, col int) string {
 // Returns ("Foo.Bar", "baz") for "Foo.Bar.baz", ("Foo.Bar.Baz", "") for "Foo.Bar.Baz",
 // ("", "do_something") for "do_something".
 func ExtractModuleAndFunction(expr string) (moduleRef string, functionName string) {
-	var moduleParts []string
+	moduleParts := make([]string, 0, 4)
 	for _, part := range strings.Split(expr, ".") {
 		if len(part) == 0 {
 			continue
@@ -175,7 +175,7 @@ type BufferFunction struct {
 // Private types (@typep) are included since they are accessible within the same file.
 func FindBufferFunctions(text string) []BufferFunction {
 	seen := make(map[string]bool)
-	var results []BufferFunction
+	results := make([]BufferFunction, 0, 16)
 	for _, line := range strings.Split(text, "\n") {
 		if m := parser.FuncDefRe.FindStringSubmatch(line); m != nil {
 			name := m[2]
@@ -261,15 +261,15 @@ func extractAliasesFromLines(lines []string, targetLine int) map[string]string {
 		depth int // do..end nesting depth when this module was opened
 	}
 
-	var stack []moduleFrame
+	stack := make([]moduleFrame, 0, 4)
 	depth := 0
 
 	// Per-scope alias collection: module name → alias map
-	var allAliases []struct {
+	allAliases := make([]struct {
 		scope string
 		short string
 		full  string
-	}
+	}, 0, 8)
 	var targetModule string
 	unscoped := targetLine < 0
 	inHeredoc := false
@@ -829,7 +829,7 @@ func FindFunctionDefinition(text string, functionName string) (int, bool) {
 // including direct calls like functionName(...) and pipe calls like |> functionName.
 // Returns 1-based line numbers. Definition lines are excluded.
 func FindBareFunctionCalls(text string, functionName string) []int {
-	var lineNums []int
+	lineNums := make([]int, 0, 8)
 	for i, line := range strings.Split(text, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if m := parser.FuncDefRe.FindStringSubmatch(trimmed); m != nil && m[2] == functionName {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -86,9 +86,9 @@ func ParseText(path, text string) ([]Definition, []Reference, error) {
 	}
 
 	lines := strings.Split(text, "\n")
-	var defs []Definition
-	var refs []Reference
-	var moduleStack []moduleFrame
+	defs := make([]Definition, 0, 32)
+	refs := make([]Reference, 0, 64)
+	moduleStack := make([]moduleFrame, 0, 4)
 	depth := 0
 	aliases := map[string]string{} // short name -> full module
 	injectors := map[string]bool{} // modules from use/import that inject bare functions

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -387,7 +387,7 @@ func (s *Store) ListFilePaths() ([]string, error) {
 	}
 	defer func() { _ = rows.Close() }()
 
-	var paths []string
+	paths := make([]string, 0, 256)
 	for rows.Next() {
 		var path string
 		if err := rows.Scan(&path); err != nil {
@@ -449,7 +449,7 @@ func (s *Store) SearchModulesBySuffix(segment string) ([]CompletionResult, error
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []CompletionResult
+	results := make([]CompletionResult, 0, 20)
 	for rows.Next() {
 		var r CompletionResult
 		if err := rows.Scan(&r.Module); err != nil {
@@ -471,7 +471,7 @@ func (s *Store) SearchModules(prefix string) ([]CompletionResult, error) {
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []CompletionResult
+	results := make([]CompletionResult, 0, 32)
 	for rows.Next() {
 		var r CompletionResult
 		if err := rows.Scan(&r.Module); err != nil {
@@ -502,7 +502,7 @@ func (s *Store) SearchSubmoduleSegments(parentModule string, segmentPrefix strin
 
 	parentDot := parentModule + "."
 	seen := make(map[string]bool)
-	var segments []string
+	segments := make([]string, 0, 16)
 	for rows.Next() {
 		var module string
 		if err := rows.Scan(&module); err != nil {
@@ -536,7 +536,7 @@ func (s *Store) ListModuleFunctions(module string, publicOnly bool) ([]Completio
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []CompletionResult
+	results := make([]CompletionResult, 0, 16)
 	for rows.Next() {
 		var r CompletionResult
 		if err := rows.Scan(&r.Module, &r.Function, &r.Arity, &r.Kind, &r.FilePath, &r.Line, &r.Params); err != nil {
@@ -573,7 +573,7 @@ func (s *Store) LookupModulesInFile(filePath string) ([]string, error) {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	var modules []string
+	modules := make([]string, 0, 4)
 	for rows.Next() {
 		var mod string
 		if err := rows.Scan(&mod); err != nil {
@@ -641,7 +641,7 @@ func (s *Store) LookupCallbackDef(behaviourModule, function string) ([]CallbackR
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []CallbackResult
+	results := make([]CallbackResult, 0, 4)
 	for rows.Next() {
 		var r CallbackResult
 		if err := rows.Scan(&r.FilePath, &r.Line, &r.Kind, &r.Arity); err != nil {
@@ -677,7 +677,7 @@ func (s *Store) LookupCallbackDefGlobal(function string, arity int) ([]CallbackR
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []CallbackResult
+	results := make([]CallbackResult, 0, 4)
 	for rows.Next() {
 		var r CallbackResult
 		if err := rows.Scan(&r.FilePath, &r.Line, &r.Kind, &r.Arity); err != nil {
@@ -706,7 +706,7 @@ func (s *Store) LookupBehavioursForFile(filePath string) ([]string, error) {
 	}
 	defer func() { _ = rows.Close() }()
 
-	var modules []string
+	modules := make([]string, 0, 4)
 	for rows.Next() {
 		var module string
 		if err := rows.Scan(&module); err != nil {
@@ -744,7 +744,7 @@ func (s *Store) LookupBehaviourImplementors(behaviourModule string) ([]Behaviour
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []BehaviourImplementorResult
+	results := make([]BehaviourImplementorResult, 0, 8)
 	for rows.Next() {
 		var r BehaviourImplementorResult
 		if err := rows.Scan(&r.Module, &r.FilePath); err != nil {
@@ -789,7 +789,7 @@ func (s *Store) queryLookup(query string, args ...interface{}) ([]LookupResult, 
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []LookupResult
+	results := make([]LookupResult, 0, 4)
 	for rows.Next() {
 		var r LookupResult
 		if err := rows.Scan(&r.FilePath, &r.Line, &r.Kind, &r.DelegateTo, &r.DelegateAs); err != nil {
@@ -819,7 +819,7 @@ func (s *Store) LookupReferences(module, function string) ([]ReferenceResult, er
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []ReferenceResult
+	results := make([]ReferenceResult, 0, 16)
 	for rows.Next() {
 		var r ReferenceResult
 		if err := rows.Scan(&r.FilePath, &r.Line, &r.Kind); err != nil {
@@ -851,7 +851,7 @@ func (s *Store) LookupReferencesByPrefix(prefix string) ([]ModuleReferenceResult
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []ModuleReferenceResult
+	results := make([]ModuleReferenceResult, 0, 16)
 	for rows.Next() {
 		var r ModuleReferenceResult
 		if err := rows.Scan(&r.Module, &r.FilePath, &r.Line, &r.Kind); err != nil {
@@ -875,7 +875,7 @@ func (s *Store) LookupModulesByPrefix(prefix string) ([]LookupResult, error) {
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []LookupResult
+	results := make([]LookupResult, 0, 8)
 	for rows.Next() {
 		var r LookupResult
 		if err := rows.Scan(&r.Module, &r.FilePath, &r.Line, &r.Kind, &r.DelegateTo, &r.DelegateAs); err != nil {
@@ -912,7 +912,7 @@ func (s *Store) LookupDelegatesTo(targetModule, targetFunction string) ([]Delega
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []DelegateEntry
+	results := make([]DelegateEntry, 0, 4)
 	for rows.Next() {
 		var r DelegateEntry
 		if err := rows.Scan(&r.Module, &r.Function, &r.DelegateAs, &r.FilePath, &r.Line); err != nil {
@@ -971,7 +971,7 @@ func (s *Store) SearchSymbols(query string, excludePathPrefix ...string) ([]Comp
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []CompletionResult
+	results := make([]CompletionResult, 0, 16)
 	for rows.Next() {
 		var r CompletionResult
 		if err := rows.Scan(&r.Module, &r.Function, &r.Arity, &r.Kind, &r.FilePath, &r.Line); err != nil {
@@ -994,7 +994,7 @@ func (s *Store) ListSubmodules(prefix string) ([]string, error) {
 	}
 	defer func() { _ = rows.Close() }()
 
-	var modules []string
+	modules := make([]string, 0, 8)
 	for rows.Next() {
 		var mod string
 		if err := rows.Scan(&mod); err != nil {
@@ -1020,7 +1020,7 @@ func (s *Store) LookupUsingModules() ([]UsingModule, error) {
 	}
 	defer func() { _ = rows.Close() }()
 
-	var modules []UsingModule
+	modules := make([]UsingModule, 0, 8)
 	for rows.Next() {
 		var m UsingModule
 		if err := rows.Scan(&m.Module, &m.FilePath); err != nil {
@@ -1077,7 +1077,7 @@ func (s *Store) LookupRefsInRange(filePath string, startLine, endLine int) ([]Ou
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []OutgoingRef
+	results := make([]OutgoingRef, 0, 8)
 	for rows.Next() {
 		var r OutgoingRef
 		if err := rows.Scan(&r.Module, &r.Function, &r.Line); err != nil {


### PR DESCRIPTION
Note: Apologies, I found no PR format established for the project.

This PR concerns the designation of explicit sizes for slices throughout the code to reduce potential geometric resizes during runtime, improving stability as well as potentially improving performance in mainly memory related areas.

**Consequences and implications:** by lacking specific sizes for the slices, golang allocates the backing array when needed but at a size that is often times very small compared to what is actually needed, therefore causing future growths which may imply not just additional memory usage but also the copying of the contents of backing arrays into newer & larger backing arrays. The exact go slice resizing formula is `newcap += (newcap + 3*threshold) >> 2` [as can be seen here](https://go.dev/src/runtime/slice.go), line 341. This effectively results in a resize factor of doubling for smaller sizes & ~1.25 for larger. This is not necessarily bad but it means that, currently, more reallocations & copies are done than actually needed. The larger the codebase, the more reallocations will be needed. The changes proposed do not change the dynamic nature of the slices: they will still grow past the initial number specified. 
This means that, in very small codebases, the code will result in higher initial ram usage than actually required; but in larger codebases, it will reduce reallocations. 

**Implementation:**


This PR changes code like `var moduleParts []string` into make statements like `moduleParts := make([]string, 0, 4)`, throughout the code.


The values used by default are chosen under my own criteria for "reasonable defaults". Based on my understanding that this LSP is intended for large codebases, the initial sizes could benefit from larger initial values, causing larger memory usage in smaller codebases but improving (potentially by quite a bit) memory usage & performance in general in larger codebase. So, if you would prefer it to be tweaked, knowing these implications / trade off, I can also do that. 



Here is a list of the changes and the rationale behind the initial sizes selected. Many of them are arbitrary, and even the ones given some more thought are based on my experience in other projects (I do not use elixir often or professionally). 


**My recommendation**: Since you know more about elixir & the kind of codebase you want to target, if you give me some hints/suggestions, I can try to tune this better to the use case. 


| Function                       | Cap | Rationale                      |
|--------------------------------|-----|--------------------------------|
| ListFilePaths                  | 256 | Full project listing           |
| SearchModulesBySuffix          | 20  | LIMIT 20 in query, small cost to start at that point              |
| SearchModules                  | 32  | LIMIT 100, but seems unlikely in small to medium sized codebases      |
| SearchSubmoduleSegments        | 16  | Arbitrary         |
| ListModuleFunctions            | 16  |  Taken from personal experience by modules on languages different from elixir            |
| LookupModulesInFile            | 4   |  at most 4 modules in a file; this is unlikely but multiples of 2 allocate nicely             |
| LookupCallbackDef              | 4   |  arbitrary              |
| LookupCallbackDefGlobal        | 4   | arbitrary               |
| LookupBehavioursForFile        | 4   | arbitrary               |
| LookupBehaviourImplementors    | 8   | arbitrary              |
| queryLookup                    | 4   | arbitrary            |
| LookupReferences               | 16  | 16 seemed like a reasonable thing as my understanding is that it could be decently large                  |
| LookupReferencesByPrefix       | 16  |  same as above                   |
| LookupModulesByPrefix          | 8   | Module defs                    |
| LookupDelegatesTo              | 4   | Doubt it ever gets past 4                     |
| SearchSymbols                  | 16  | the query has a LIMIT to 50, but unsure if this will actually be the case, so 16 seemed okay                      |
| ListSubmodules                 | 8   | 8  seems okay for the average project           |
| LookupUsingModules             | 8   |  same as above             |
| LookupRefsInRange              | 8   | arbitrary         |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to slice initialization (`make` with capacity) and should not affect correctness, though chosen capacities could modestly increase baseline memory use on small projects.
> 
> **Overview**
> Reduces runtime slice reallocations by switching various `var x []T` declarations to `make([]T, 0, N)` with *default capacities* across the Elixir LSP (`internal/lsp/elixir.go`), parser (`internal/parser/parser.go`), and SQLite-backed store query helpers (`internal/store/store.go`).
> 
> No query logic, parsing behavior, or returned data shapes are changed; this is a performance/memory allocation tweak with some increased upfront allocation in exchange for fewer growth reallocations under load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e647480113eefbe7ea82d5c5f900b6119729692b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->