### PR TITLE
extracted code to prevent duplicated execution of string index search

### DIFF
--- a/internal/lsp/elixir.go
+++ b/internal/lsp/elixir.go
@@ -179,8 +179,9 @@ func FindBufferFunctions(text string) []BufferFunction {
 	for _, line := range strings.Split(text, "\n") {
 		if m := parser.FuncDefRe.FindStringSubmatch(line); m != nil {
 			name := m[2]
-			maxArity := parser.ExtractArity(line, name)
-			minArity := maxArity - parser.CountDefaultParams(line, name)
+			paramContent := parser.FindParamContent(line, name)
+			maxArity := parser.ArityFromParams(paramContent)
+			minArity := maxArity - parser.DefaultsFromParams(paramContent)
 			allParamNames := parser.ExtractParamNames(line, name)
 			for arity := minArity; arity <= maxArity; arity++ {
 				key := name + "/" + strconv.Itoa(arity)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -377,8 +377,9 @@ func ParseText(path, text string) ([]Definition, []Reference, error) {
 
 			if currentModule != "" {
 				if kind, funcName, ok := ScanFuncDef(rest); ok {
-					maxArity := ExtractArity(line, funcName)
-					defaultCount := CountDefaultParams(line, funcName)
+					paramContent := FindParamContent(line, funcName)
+					maxArity := ArityFromParams(paramContent)
+					defaultCount := DefaultsFromParams(paramContent)
 					minArity := maxArity - defaultCount
 
 					var delegateTo, delegateAs string
@@ -775,25 +776,34 @@ func findDelegateToAndAs(lines []string, startIdx int, aliases map[string]string
 	return targetModule, targetFunc
 }
 
-// ExtractArity counts the number of arguments in a function definition line.
-// It finds the first parenthesized argument list after the function name and
-// counts top-level commas, respecting nested parens/brackets/braces.
-func ExtractArity(line string, funcName string) int {
+// FindParamContent locates funcName in line, finds the opening parenthesis
+// after it, and returns the substring starting after that '('. Returns ""
+// if funcName is not found or has no parenthesized arguments.
+// This allows callers that need both arity and default counts to avoid
+// repeating the Index + IndexByte lookup.
+func FindParamContent(line, funcName string) string {
 	idx := strings.Index(line, funcName)
 	if idx < 0 {
-		return 0
+		return ""
 	}
 	rest := line[idx+len(funcName):]
-
 	parenIdx := strings.IndexByte(rest, '(')
 	if parenIdx < 0 {
+		return ""
+	}
+	return rest[parenIdx+1:]
+}
+
+// ArityFromParams counts the number of top-level arguments in the parameter
+// content string (as returned by FindParamContent). Respects nested
+// parens/brackets/braces and skips string literals.
+func ArityFromParams(inside string) int {
+	if inside == "" {
 		return 0
 	}
-
 	depth := 1
 	commas := 0
 	hasContent := false
-	inside := rest[parenIdx+1:]
 	for i := 0; i < len(inside); i++ {
 		ch := inside[i]
 		// Skip string and charlist literals
@@ -822,31 +832,21 @@ func ExtractArity(line string, funcName string) int {
 			hasContent = true
 		}
 	}
-
 	if hasContent {
 		return commas + 1
 	}
 	return 0
 }
 
-// CountDefaultParams counts the number of parameters with default values (\\)
-// in a function definition line. Only counts defaults at the top-level param
-// depth, not inside nested structures.
-func CountDefaultParams(line string, funcName string) int {
-	idx := strings.Index(line, funcName)
-	if idx < 0 {
+// DefaultsFromParams counts parameters with default values (\\) in the
+// parameter content string (as returned by FindParamContent). Only counts
+// defaults at the top-level param depth, not inside nested structures.
+func DefaultsFromParams(inside string) int {
+	if inside == "" {
 		return 0
 	}
-	rest := line[idx+len(funcName):]
-
-	parenIdx := strings.IndexByte(rest, '(')
-	if parenIdx < 0 {
-		return 0
-	}
-
 	depth := 1
 	defaults := 0
-	inside := rest[parenIdx+1:]
 	for i := 0; i < len(inside); i++ {
 		ch := inside[i]
 		// Skip string and charlist literals
@@ -870,6 +870,20 @@ func CountDefaultParams(line string, funcName string) int {
 		}
 	}
 	return defaults
+}
+
+// ExtractArity counts the number of arguments in a function definition line.
+// It finds the first parenthesized argument list after the function name and
+// counts top-level commas, respecting nested parens/brackets/braces.
+func ExtractArity(line string, funcName string) int {
+	return ArityFromParams(FindParamContent(line, funcName))
+}
+
+// CountDefaultParams counts the number of parameters with default values (\\)
+// in a function definition line. Only counts defaults at the top-level param
+// depth, not inside nested structures.
+func CountDefaultParams(line string, funcName string) int {
+	return DefaultsFromParams(FindParamContent(line, funcName))
 }
 
 // ExtractParamNames extracts readable parameter names from a function


### PR DESCRIPTION
Note: Apologies, I found no PR format established for the project.

This PR is about avoiding duplicate work by extracting the common calls accross `parser.ExtractArity(line, name)` and `parser.CountDefaultParams(line, name)`.  to the string functions  `strings.Index(line, funcName)` and `parenIdx := strings.IndexByte(rest, '(')`. String functions are typically considered expensive, as require browsing & comparing many bytes.

Consequences and implications: since the code was being run twice (and in every case that CountDefaultParams was called, ExtractArity had been called beforehand, meaning it happened quite often), by isolating the code that run twice we can avoid the expensive, constant string index operations, reducing in less instructions.

Implementation:

- I propose the creation of parser.FindParamContent() to do the common string index operations. 
- Then, I create ArityFromParams & DefaultsFromParams to contain the individual parts of what before was ExtractArity CountDefaultParams 
- I propose maintaining the original function calls `parser.ExtractArity(line, name)` & `parser.CountDefaultParams(line, name)`, as they were being exported. I adapt them to call to the new functions.
- I update comments to reflect the changes proposed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to parsing helpers for function arity/default-parameter detection; main risk is subtle behavior drift in edge-case Elixir function definitions.
> 
> **Overview**
> Reduces duplicated string scanning when parsing Elixir function definitions by extracting shared lookup logic into `parser.FindParamContent` and splitting computation into `ArityFromParams`/`DefaultsFromParams`.
> 
> Updates both the indexer (`ParseText`) and LSP buffer scanning (`FindBufferFunctions`) to reuse the extracted parameter substring rather than recomputing arity and default counts separately, while keeping the existing exported APIs `ExtractArity` and `CountDefaultParams` as thin wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8571a67068dc8353db6f956e14d4e4e6ab8432ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->