### PR TITLE
Update Zed Extension description

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ lspconfig.dexter.setup({})
 
 Install the [dexter-zed](https://github.com/remoteoss/dexter-zed) extension:
 
-1. Clone the extension: `git clone https://github.com/remoteoss/dexter-zed.git`
-2. In Zed, open the command palette (`Cmd+Shift+P`) and run **"zed: install dev extension"**
-3. Select the `dexter-zed/` directory
+1. In Zed, open **Extensions** (`Cmd+Shift+X`) and search for **"Dexter"**
+2. Click **Install**
+3. Open any Elixir file — the index builds automatically on first startup
 
 Configure the binary path in Zed's `settings.json`:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that updates Zed setup steps; no runtime or API behavior is modified.
> 
> **Overview**
> Updates the `README.md` Zed setup section to reflect installing the `dexter-zed` extension via Zed’s Extensions UI (search/install) instead of cloning and installing a dev extension, and notes that opening an Elixir file triggers the initial index build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ff6bbed10849d85d13892adff374fb006b9a9e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->