### PR TITLE
Remove periodic reindexing

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -255,18 +255,6 @@ func (s *Server) watchGitHead() {
 	}()
 }
 
-// periodicReindex runs backgroundReindex on a fixed interval to catch files
-// created or deleted outside the editor.
-func (s *Server) periodicReindex() {
-	go func() {
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-
-		for range ticker.C {
-			s.backgroundReindex()
-		}
-	}()
-}
 
 // notifyOTPMismatch checks stderr output for an OTP version mismatch and
 // sends a one-time warning to the editor so the user doesn't have to dig
@@ -355,7 +343,6 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 		s.initialized = true
 		s.backgroundReindex()
 		s.watchGitHead()
-		s.periodicReindex()
 	}
 
 	if params.Capabilities.Window != nil && params.Capabilities.Window.ShowDocument != nil {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -255,7 +255,6 @@ func (s *Server) watchGitHead() {
 	}()
 }
 
-
 // notifyOTPMismatch checks stderr output for an OTP version mismatch and
 // sends a one-time warning to the editor so the user doesn't have to dig
 // through logs.


### PR DESCRIPTION
Periodic reindexing was added as a fallback for when changes occur outside of the editor environment that could cause the index to get stale. However, this has a few drawbacks:

- By indexing every 30 seconds, we force a full crawl of the filesystem. This is usually around 800ms and causes a spike in CPU (about 25% on my machine) every 30 seconds, not to mention unnecessary file IO.
- If multiple editors are open, each running the LSP, we now have N spikes every 30 seconds, which is even worse.

After further testing, I found that the editor does a good job of tracking files across the project and issuing `didChangeWatchedFiles` events. So I believe we can safely get rid of this periodic reindexing without issue. We still do a full scan on startup to look for stale files, so we shouldn't have any edge cases from editors not being open.

If users start reporting stale index issues, we can revisit, but the potential solutions if the editor is missing changed files are either re-adding periodic indexing or tracking the files ourselves directly with fsevent, which work the editor should be handling. (Maybe there's another approach I'm missing though.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes the 30s full-project reindex fallback, which reduces CPU/IO but may allow the index to become stale if editors fail to emit file-watcher events in some environments.
> 
> **Overview**
> Removes the LSP server’s periodic 30-second `backgroundReindex` ticker and stops starting it during `Initialize`, relying on startup indexing plus event-driven updates (e.g., watched file changes and `watchGitHead`) to keep the index current.
> 
> This eliminates recurring full filesystem crawls to reduce CPU and IO overhead, especially when multiple editors are running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 475fc678b5941f7948ce535e70477b49d0182f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->