### PR TITLE
fix: alias handling for multi-line declarations

### DIFF
--- a/internal/lsp/elixir.go
+++ b/internal/lsp/elixir.go
@@ -266,12 +266,14 @@ func extractAliasesFromLines(lines []string, targetLine int) map[string]string {
 	var stack []moduleFrame
 	depth := 0
 
-	// Per-scope alias collection: module name → alias map
-	var allAliases []struct {
+	type alias struct {
 		scope string
 		short string
 		full  string
 	}
+
+	// Per-scope alias collection: module name → alias map
+	var allAliases []alias
 	var targetModule string
 	unscoped := targetLine < 0
 	inHeredoc := false
@@ -331,23 +333,25 @@ func extractAliasesFromLines(lines []string, targetLine int) map[string]string {
 			return s
 		}
 
+		getFullModuleAlias := func(fullMod string) string {
+			parts := strings.Split(fullMod, ".")
+			return parts[len(parts)-1]
+		}
+
 		// Collect alias declarations
 		if m := parser.AliasAsRe.FindStringSubmatch(line); m != nil {
 			resolved := resolve(m[1])
 			if !strings.Contains(resolved, "__MODULE__") {
+				short := ""
 				if m[2] != "" {
-					// alias Mod, as: Name — same line
-					allAliases = append(allAliases, struct {
-						scope, short, full string
-					}{currentModule, m[2], resolved})
-				} else {
-					// alias Mod, — trailing comma, peek next line for as:
-					if n := aliasNextLineAsRe.FindStringSubmatch(nextLineAt(lines, i)); n != nil {
-						allAliases = append(allAliases, struct {
-							scope, short, full string
-						}{currentModule, n[1], resolved})
-					}
+					// alias Mod, as: Name - same line
+					short = m[2]
+				} else if n := aliasNextLineAsRe.FindStringSubmatch(nextLineAt(lines, i)); n != nil { // alias Mod, - trailing comma, peek next line for as:
+					short = n[1]
+				} else { // other keyword opts or no as: - normal alias
+					short = getFullModuleAlias(resolved)
 				}
+				allAliases = append(allAliases, alias{currentModule, short, resolved})
 			}
 		} else if m := aliasMultiRe.FindStringSubmatch(line); m != nil {
 			base := resolve(m[1])
@@ -362,9 +366,7 @@ func extractAliasesFromLines(lines []string, targetLine int) map[string]string {
 					if len(name) > 0 && unicode.IsUpper(rune(name[0])) {
 						childName := parser.ScanModuleName(name)
 						if childName != "" {
-							allAliases = append(allAliases, struct {
-								scope, short, full string
-							}{currentModule, childName, base + "." + childName})
+							allAliases = append(allAliases, alias{currentModule, childName, base + "." + childName})
 						}
 					}
 				}
@@ -372,10 +374,7 @@ func extractAliasesFromLines(lines []string, targetLine int) map[string]string {
 		} else if m := parser.AliasRe.FindStringSubmatch(line); m != nil {
 			fullMod := resolve(m[1])
 			if !strings.Contains(fullMod, "__MODULE__") {
-				parts := strings.Split(fullMod, ".")
-				allAliases = append(allAliases, struct {
-					scope, short, full string
-				}{currentModule, parts[len(parts)-1], fullMod})
+				allAliases = append(allAliases, alias{currentModule, getFullModuleAlias(fullMod), fullMod})
 			}
 		}
 	}
@@ -417,21 +416,18 @@ func nextLineAt(lines []string, i int) string {
 // lines and idx are used for look-ahead on multi-line constructs.
 func extractAliasFromLine(lines []string, idx int, aliases map[string]string, resolveAlias func(string) string) (map[string]string, bool) {
 	line := lines[idx]
+	if aliases == nil {
+		aliases = make(map[string]string)
+	}
 	if m := parser.AliasAsRe.FindStringSubmatch(line); m != nil {
 		resolved := resolveAlias(m[1])
 		if m[2] != "" {
 			// alias Mod, as: Name — same line
-			if aliases == nil {
-				aliases = make(map[string]string)
-			}
 			aliases[m[2]] = resolved
 			return aliases, true
 		}
 		// alias Mod, — trailing comma, peek next line for as:
 		if n := aliasNextLineAsRe.FindStringSubmatch(nextLineAt(lines, idx)); n != nil {
-			if aliases == nil {
-				aliases = make(map[string]string)
-			}
 			aliases[n[1]] = resolved
 			return aliases, true
 		}
@@ -448,9 +444,6 @@ func extractAliasFromLine(lines []string, idx int, aliases map[string]string, re
 			if len(name) > 0 && unicode.IsUpper(rune(name[0])) {
 				childName := parser.ScanModuleName(name)
 				if childName != "" {
-					if aliases == nil {
-						aliases = make(map[string]string)
-					}
 					aliases[childName] = base + "." + childName
 				}
 			}
@@ -460,9 +453,6 @@ func extractAliasFromLine(lines []string, idx int, aliases map[string]string, re
 	if m := parser.AliasRe.FindStringSubmatch(line); m != nil {
 		resolved := resolveAlias(m[1])
 		parts := strings.Split(resolved, ".")
-		if aliases == nil {
-			aliases = make(map[string]string)
-		}
 		aliases[parts[len(parts)-1]] = resolved
 		return aliases, true
 	}

--- a/internal/lsp/elixir.go
+++ b/internal/lsp/elixir.go
@@ -204,12 +204,13 @@ func FindBufferFunctions(text string) []BufferFunction {
 }
 
 var (
-	aliasMultiRe    = regexp.MustCompile(`^\s*alias\s+([A-Za-z0-9_.]+)\.{([^}]+)}`)
-	importRe        = regexp.MustCompile(`^\s*import\s+([A-Za-z0-9_.]+)`)
-	useRe           = regexp.MustCompile(`^\s*use\s+([A-Za-z0-9_.]+)`)
-	usingDefRe      = regexp.MustCompile(`^\s*defmacro\s+__using__`)
-	moduleAttrDefRe = regexp.MustCompile(`^\s*@([a-z_][a-z0-9_]*)\s+[^@]`)
-	keywordModuleRe = regexp.MustCompile(`Keyword\.(?:put_new|put)\([^,]+,\s*:[a-z_]+,\s*([A-Z][A-Za-z0-9_.]+)\)`)
+	aliasMultiRe      = regexp.MustCompile(`^\s*alias\s+([A-Za-z0-9_.]+)\.\{([^}]*)\}?`)
+	aliasNextLineAsRe = regexp.MustCompile(`^\s*as:\s*([A-Za-z0-9_]+)`)
+	importRe          = regexp.MustCompile(`^\s*import\s+([A-Za-z0-9_.]+)`)
+	useRe             = regexp.MustCompile(`^\s*use\s+([A-Za-z0-9_.]+)`)
+	usingDefRe        = regexp.MustCompile(`^\s*defmacro\s+__using__`)
+	moduleAttrDefRe   = regexp.MustCompile(`^\s*@([a-z_][a-z0-9_]*)\s+[^@]`)
+	keywordModuleRe   = regexp.MustCompile(`Keyword\.(?:put_new|put)\([^,]+,\s*:[a-z_]+,\s*([A-Z][A-Za-z0-9_.]+)\)`)
 
 	// Dynamic opt-binding patterns inside __using__ bodies.
 	// var = Keyword.get/pop(opts, :key, Default)
@@ -334,19 +335,37 @@ func extractAliasesFromLines(lines []string, targetLine int) map[string]string {
 		if m := parser.AliasAsRe.FindStringSubmatch(line); m != nil {
 			resolved := resolve(m[1])
 			if !strings.Contains(resolved, "__MODULE__") {
-				allAliases = append(allAliases, struct {
-					scope, short, full string
-				}{currentModule, m[2], resolved})
+				if m[2] != "" {
+					// alias Mod, as: Name — same line
+					allAliases = append(allAliases, struct {
+						scope, short, full string
+					}{currentModule, m[2], resolved})
+				} else {
+					// alias Mod, — trailing comma, peek next line for as:
+					if n := aliasNextLineAsRe.FindStringSubmatch(nextLineAt(lines, i)); n != nil {
+						allAliases = append(allAliases, struct {
+							scope, short, full string
+						}{currentModule, n[1], resolved})
+					}
+				}
 			}
 		} else if m := aliasMultiRe.FindStringSubmatch(line); m != nil {
 			base := resolve(m[1])
 			if !strings.Contains(base, "__MODULE__") {
-				for _, name := range strings.Split(m[2], ",") {
-					name = strings.TrimSpace(name)
+				inner := m[2]
+				if strings.TrimSpace(inner) == "" {
+					// Multi-line: alias MyApp.{\n  Foo,\n  Bar\n}
+					inner = parser.CollectBraceContent(lines, i+1)
+				}
+				for _, seg := range strings.Split(inner, ",") {
+					name := strings.TrimSpace(seg)
 					if len(name) > 0 && unicode.IsUpper(rune(name[0])) {
-						allAliases = append(allAliases, struct {
-							scope, short, full string
-						}{currentModule, name, base + "." + name})
+						childName := parser.ScanModuleName(name)
+						if childName != "" {
+							allAliases = append(allAliases, struct {
+								scope, short, full string
+							}{currentModule, childName, base + "." + childName})
+						}
 					}
 				}
 			}
@@ -383,27 +402,57 @@ func ExtractImports(text string) []string {
 	return imports
 }
 
+// nextLineAt returns lines[i+1] if it exists, otherwise "".
+func nextLineAt(lines []string, i int) string {
+	if i+1 < len(lines) {
+		return lines[i+1]
+	}
+	return ""
+}
+
 // extractAliasFromLine checks whether line matches an alias declaration
 // (alias X, as: Y / alias X.{A, B} / alias X.Y) and, if so, records it in
 // aliases and returns the (possibly newly-created) map plus true. Returns
 // (aliases, false) when the line is not an alias declaration.
-func extractAliasFromLine(line string, aliases map[string]string, resolveAlias func(string) string) (map[string]string, bool) {
+// lines and idx are used for look-ahead on multi-line constructs.
+func extractAliasFromLine(lines []string, idx int, aliases map[string]string, resolveAlias func(string) string) (map[string]string, bool) {
+	line := lines[idx]
 	if m := parser.AliasAsRe.FindStringSubmatch(line); m != nil {
-		if aliases == nil {
-			aliases = make(map[string]string)
+		resolved := resolveAlias(m[1])
+		if m[2] != "" {
+			// alias Mod, as: Name — same line
+			if aliases == nil {
+				aliases = make(map[string]string)
+			}
+			aliases[m[2]] = resolved
+			return aliases, true
 		}
-		aliases[m[2]] = resolveAlias(m[1])
-		return aliases, true
+		// alias Mod, — trailing comma, peek next line for as:
+		if n := aliasNextLineAsRe.FindStringSubmatch(nextLineAt(lines, idx)); n != nil {
+			if aliases == nil {
+				aliases = make(map[string]string)
+			}
+			aliases[n[1]] = resolved
+			return aliases, true
+		}
 	}
 	if m := aliasMultiRe.FindStringSubmatch(line); m != nil {
 		base := resolveAlias(m[1])
-		for _, name := range strings.Split(m[2], ",") {
-			name = strings.TrimSpace(name)
+		inner := m[2]
+		if strings.TrimSpace(inner) == "" {
+			// Multi-line: alias MyApp.{\n  Foo,\n  Bar\n}
+			inner = parser.CollectBraceContent(lines, idx+1)
+		}
+		for _, seg := range strings.Split(inner, ",") {
+			name := strings.TrimSpace(seg)
 			if len(name) > 0 && unicode.IsUpper(rune(name[0])) {
-				if aliases == nil {
-					aliases = make(map[string]string)
+				childName := parser.ScanModuleName(name)
+				if childName != "" {
+					if aliases == nil {
+						aliases = make(map[string]string)
+					}
+					aliases[childName] = base + "." + childName
 				}
-				aliases[name] = base + "." + name
 			}
 		}
 		return aliases, true
@@ -493,7 +542,7 @@ func parseHelperQuoteBlock(lines []string, helperName string, fileAliases map[st
 			transUses = append(transUses, resolveAlias(m[1]))
 			continue
 		}
-		if updated, matched := extractAliasFromLine(line, aliases, resolveAlias); matched {
+		if updated, matched := extractAliasFromLine(lines, i, aliases, resolveAlias); matched {
 			aliases = updated
 			continue
 		}
@@ -707,7 +756,7 @@ func parseUsingBody(text string) (imported []string, inlineDefs map[string][]inl
 			continue
 		}
 
-		if updated, matched := extractAliasFromLine(line, aliases, resolveAlias); matched {
+		if updated, matched := extractAliasFromLine(lines, i, aliases, resolveAlias); matched {
 			aliases = updated
 			continue
 		}

--- a/internal/lsp/elixir_test.go
+++ b/internal/lsp/elixir_test.go
@@ -201,6 +201,14 @@ func TestExtractAliases(t *testing.T) {
 		}
 	})
 
+	t.Run("alias with warn: on next line", func(t *testing.T) {
+		text := "defmodule MyApp.Core do\n  alias MyApp.Accounts.Worker,\n    warn: false\nend"
+		aliases := ExtractAliases(text)
+		if aliases["Worker"] != "MyApp.Accounts.Worker" {
+			t.Errorf("Worker: got %q, want MyApp.Accounts.Worker", aliases["Worker"])
+		}
+	})
+
 	t.Run("multi-alias", func(t *testing.T) {
 		aliases := ExtractAliases("  alias MyApp.Handlers.{Foo, Bar, Baz}")
 		if aliases["Foo"] != "MyApp.Handlers.Foo" {

--- a/internal/lsp/elixir_test.go
+++ b/internal/lsp/elixir_test.go
@@ -193,6 +193,14 @@ func TestExtractAliases(t *testing.T) {
 		}
 	})
 
+	t.Run("alias with as: on next line", func(t *testing.T) {
+		text := "  alias MyApp.Serializer.Date,\n    as: DateSerializer"
+		aliases := ExtractAliases(text)
+		if aliases["DateSerializer"] != "MyApp.Serializer.Date" {
+			t.Errorf("got %q, want MyApp.Serializer.Date", aliases["DateSerializer"])
+		}
+	})
+
 	t.Run("multi-alias", func(t *testing.T) {
 		aliases := ExtractAliases("  alias MyApp.Handlers.{Foo, Bar, Baz}")
 		if aliases["Foo"] != "MyApp.Handlers.Foo" {
@@ -203,6 +211,20 @@ func TestExtractAliases(t *testing.T) {
 		}
 		if aliases["Baz"] != "MyApp.Handlers.Baz" {
 			t.Errorf("Baz: got %q", aliases["Baz"])
+		}
+	})
+
+	t.Run("multi-alias across lines", func(t *testing.T) {
+		text := "defmodule MyApp.Web do\n  alias MyApp.Handlers.{\n    Foo,\n    Bar,\n    Baz\n  }\nend"
+		aliases := ExtractAliases(text)
+		if aliases["Foo"] != "MyApp.Handlers.Foo" {
+			t.Errorf("Foo: got %q, want MyApp.Handlers.Foo", aliases["Foo"])
+		}
+		if aliases["Bar"] != "MyApp.Handlers.Bar" {
+			t.Errorf("Bar: got %q, want MyApp.Handlers.Bar", aliases["Bar"])
+		}
+		if aliases["Baz"] != "MyApp.Handlers.Baz" {
+			t.Errorf("Baz: got %q, want MyApp.Handlers.Baz", aliases["Baz"])
 		}
 	})
 
@@ -422,6 +444,23 @@ end
 		aliases := ExtractAliasesInScope(stringSrc, 7)
 		if aliases["Settings"] != "MyApp.Settings" {
 			t.Errorf("expected Settings alias with do/end in strings, got %q", aliases["Settings"])
+		}
+	})
+
+	t.Run("multiline alias as: resolves in scope", func(t *testing.T) {
+		multilineSrc := `defmodule MyApp.Controller do
+  alias MyApp.Serializer.Date,
+    as: DateSerializer
+
+  def index do
+    DateSerializer.serialize(%{})
+  end
+end
+`
+		// Line 5 = "DateSerializer.serialize" inside the module
+		aliases := ExtractAliasesInScope(multilineSrc, 5)
+		if aliases["DateSerializer"] != "MyApp.Serializer.Date" {
+			t.Errorf("got %q, want MyApp.Serializer.Date", aliases["DateSerializer"])
 		}
 	})
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -7,12 +7,13 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 // Shared regex patterns used by both the parser and the LSP.
 var (
 	AliasRe   = regexp.MustCompile(`^\s*alias\s+([A-Za-z0-9_.]+)`)
-	AliasAsRe = regexp.MustCompile(`^\s*alias\s+([A-Za-z0-9_.]+)\s*,\s*as:\s*([A-Za-z0-9_]+)`)
+	AliasAsRe = regexp.MustCompile(`^\s*alias\s+([A-Za-z0-9_.]+)\s*,\s*(?:as:\s*([A-Za-z0-9_]+))?\s*$`)
 	FuncDefRe = regexp.MustCompile(`^\s*(defp?|defmacrop?|defguardp?|defdelegate)\s+([a-z_][a-z0-9_?!]*)[\s(,]`)
 	TypeDefRe = regexp.MustCompile(`^\s*@(typep?|opaque)\s+([a-z_][a-z0-9_?!]*)`)
 )
@@ -157,43 +158,51 @@ func ParseText(path, text string) ([]Definition, []Reference, error) {
 					// Multi-alias: alias MyApp.{Accounts, Users}
 					// ScanModuleName consumes the trailing "." so remaining starts with "{"
 					if strings.HasPrefix(remaining, "{") {
+						// Collect inner content — may be single-line or span multiple lines
+						var inner string
 						braceEnd := strings.IndexByte(remaining, '}')
 						if braceEnd >= 0 {
-							inner := remaining[1:braceEnd]
-							// Trim trailing dot from parent module name
-							parent := strings.TrimRight(moduleName, ".")
-							parentResolved := resolveModule(parent, currentModule)
-							for _, segment := range strings.Split(inner, ",") {
-								segment = strings.TrimSpace(segment)
-								childName := ScanModuleName(segment)
-								if childName != "" {
-									fullChild := parentResolved + "." + childName
-									aliasKey := childName
-									if dot := strings.LastIndexByte(childName, '.'); dot >= 0 {
-										aliasKey = childName[dot+1:]
-									}
-									aliases[aliasKey] = fullChild
-									if !strings.Contains(fullChild, "__MODULE__") {
-										refs = append(refs, Reference{Module: fullChild, Line: lineNum, FilePath: path, Kind: "alias"})
-									}
+							inner = remaining[1:braceEnd]
+						} else {
+							inner = CollectBraceContent(lines, lineIdx+1)
+						}
+
+						// Trim trailing dot from parent module name
+						parent := strings.TrimRight(moduleName, ".")
+						parentResolved := resolveModule(parent, currentModule)
+
+						for _, segment := range strings.Split(inner, ",") {
+							segment = strings.TrimSpace(segment)
+							childName := ScanModuleName(segment)
+							if childName != "" {
+								fullChild := parentResolved + "." + childName
+								aliasKey := childName
+								if dot := strings.LastIndexByte(childName, '.'); dot >= 0 {
+									aliasKey = childName[dot+1:]
+								}
+								aliases[aliasKey] = fullChild
+								if !strings.Contains(fullChild, "__MODULE__") {
+									refs = append(refs, Reference{Module: fullChild, Line: lineNum, FilePath: path, Kind: "alias"})
 								}
 							}
-							continue
+						}
+						continue
+					}
+
+					var asStr string
+					if strings.HasPrefix(remaining, ", as:") {
+						asStr = strings.TrimLeft(remaining[5:], " \t") // skip ", as:"
+					} else if strings.HasPrefix(remaining, ",as:") {
+						asStr = strings.TrimLeft(remaining[4:], " \t") // skip ",as:"
+					} else if strings.TrimSpace(remaining) == "," && lineIdx+1 < len(lines) {
+						// Multiline: alias Mod,\n  as: Name
+						nextLine := strings.TrimLeft(lines[lineIdx+1], " \t")
+						if strings.HasPrefix(nextLine, "as:") {
+							asStr = strings.TrimLeft(nextLine[3:], " \t")
 						}
 					}
 
-					if strings.HasPrefix(remaining, ", as:") {
-						asStr := strings.TrimLeft(remaining[5:], " \t") // skip ", as:"
-						asName := scanIdentifier(asStr)
-						if asName != "" {
-							resolved := resolveModule(moduleName, currentModule)
-							if !strings.Contains(resolved, "__MODULE__") {
-								aliases[asName] = resolved
-								refs = append(refs, Reference{Module: resolved, Line: lineNum, FilePath: path, Kind: "alias"})
-							}
-						}
-					} else if strings.HasPrefix(remaining, ",as:") {
-						asStr := strings.TrimLeft(remaining[4:], " \t") // skip ",as:"
+					if asStr != "" {
 						asName := scanIdentifier(asStr)
 						if asName != "" {
 							resolved := resolveModule(moduleName, currentModule)
@@ -733,6 +742,32 @@ func containsFnKeyword(code string) bool {
 
 func isIdentChar(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}
+
+// CollectBraceContent scans lines starting at startIdx for content between an
+// already-opened '{' and the closing '}'. Returns the comma-joined inner
+// content. Stops early if a line is empty or doesn't start with an uppercase
+// letter (indicating the brace block has ended without a closing brace).
+func CollectBraceContent(lines []string, startIdx int) string {
+	var parts []string
+	limit := min(len(lines), startIdx+50)
+	for i := startIdx; i < limit; i++ {
+		line := lines[i]
+		if braceEnd := strings.IndexByte(line, '}'); braceEnd >= 0 {
+			parts = append(parts, line[:braceEnd])
+			return strings.Join(parts, ",")
+		}
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) == 0 || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if unicode.IsUpper(rune(trimmed[0])) {
+			parts = append(parts, trimmed)
+		} else {
+			return strings.Join(parts, ",")
+		}
+	}
+	return ""
 }
 
 // findDelegateTo searches the current line and up to 5 subsequent lines for a to: target,

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -13,7 +13,7 @@ import (
 // Shared regex patterns used by both the parser and the LSP.
 var (
 	AliasRe   = regexp.MustCompile(`^\s*alias\s+([A-Za-z0-9_.]+)`)
-	AliasAsRe = regexp.MustCompile(`^\s*alias\s+([A-Za-z0-9_.]+)\s*,\s*(?:as:\s*([A-Za-z0-9_]+))?\s*$`)
+	AliasAsRe = regexp.MustCompile(`^\s*alias\s+([A-Za-z0-9_.]+)\s*,\s*(?:as:\s*([A-Za-z0-9_]+))?`)
 	FuncDefRe = regexp.MustCompile(`^\s*(defp?|defmacrop?|defguardp?|defdelegate)\s+([a-z_][a-z0-9_?!]*)[\s(,]`)
 	TypeDefRe = regexp.MustCompile(`^\s*@(typep?|opaque)\s+([a-z_][a-z0-9_?!]*)`)
 )

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1772,6 +1772,83 @@ end
 	}
 }
 
+func TestParseFileReferences_AliasAsMultiline(t *testing.T) {
+	path := writeTempFile(t, `defmodule MyApp.Controller do
+  alias MyApp.Serializer.Date,
+    as: DateSerializer
+
+  def index do
+    DateSerializer.serialize(%{})
+  end
+end
+`)
+
+	_, refs, err := ParseFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	callRefs := filterRefs(refs, "call")
+	found := false
+	for _, r := range callRefs {
+		if r.Module == "MyApp.Serializer.Date" && r.Function == "serialize" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected DateSerializer.serialize to resolve to MyApp.Serializer.Date.serialize; refs: %+v", callRefs)
+	}
+}
+
+func TestParseFileReferences_MultiAliasMultiline(t *testing.T) {
+	path := writeTempFile(t, `defmodule MyApp.Controller do
+  alias MyApp.Handlers.{
+    Accounts,
+    Users,
+    Profiles
+  }
+
+  def index do
+    Accounts.list()
+    Users.get(1)
+  end
+end
+`)
+
+	_, refs, err := ParseFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aliasRefs := filterRefs(refs, "alias")
+	expectedAliases := map[string]bool{
+		"MyApp.Handlers.Accounts": false,
+		"MyApp.Handlers.Users":    false,
+		"MyApp.Handlers.Profiles": false,
+	}
+	for _, r := range aliasRefs {
+		if _, ok := expectedAliases[r.Module]; ok {
+			expectedAliases[r.Module] = true
+		}
+	}
+	for mod, found := range expectedAliases {
+		if !found {
+			t.Errorf("expected alias ref to %s; alias refs: %+v", mod, aliasRefs)
+		}
+	}
+
+	callRefs := filterRefs(refs, "call")
+	found := false
+	for _, r := range callRefs {
+		if r.Module == "MyApp.Handlers.Accounts" && r.Function == "list" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected Accounts.list to resolve to MyApp.Handlers.Accounts.list; refs: %+v", callRefs)
+	}
+}
+
 func TestParseFileReferences_SkipsHeredocs(t *testing.T) {
 	path := writeTempFile(t, `defmodule MyApp.Foo do
   @doc """


### PR DESCRIPTION
Hi! First of all, thanks for the project!

This PR fixes a bug where multi-line alias declarations were not parsed correctly:

1. `as:` on the next line:
   ```elixir
   alias MyApp.Accounts,
     as: Accounts
   ```

2. Braces opening on one line with entries on subsequent lines:
   ```elixir
   alias MyApp.{
     Accounts,
     Users,
     Profiles
   }
   ```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Parsing logic for Elixir aliases is expanded to look ahead across lines and collect brace blocks, which could subtly change reference resolution for some files. Changes are well-covered by new tests but touch core LSP/parser extraction paths.
> 
> **Overview**
> Fixes Elixir alias extraction so **multi-line alias forms** are recognized and resolved: `alias Mod,` with `as:` on the following line, and `alias Parent.{` with children listed on subsequent lines.
> 
> This updates both the LSP alias scanners and the core `parser.ParseText` alias/reference extraction (including a shared `CollectBraceContent` helper), and adds regression tests to ensure alias refs and subsequent call resolution work for these multi-line patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 126c0e6f9d4677ea6551684e9f46cc25d83cdbe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->