### PR TITLE
Update Zed Extension docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,26 @@ lspconfig.dexter.setup({})
 
 ### Zed
 
-Install the [dexter-zed](https://github.com/remoteoss/dexter-zed) extension:
+Dexter is included in Zed's official [Elixir extension](https://github.com/zed-extensions/elixir). No extra installation needed — just enable it in your Zed `settings.json`:
 
-1. In Zed, open **Extensions** (`Cmd+Shift+X`) and search for **"Dexter"**
-2. Click **Install**
-3. Open any Elixir file — the index builds automatically on first startup
+```json
+{
+  "languages": {
+    "Elixir": {
+      "language_servers": ["dexter", "!elixir-ls", "!expert"]
+    },
+    "HEEx": {
+      "language_servers": ["dexter", "!elixir-ls", "!expert"]
+    }
+  }
+}
+```
 
-Configure the binary path in Zed's `settings.json`:
+Open any Elixir file — the binary will be downloaded automatically on first startup.
+
+If you already have Dexter installed via [mise](https://mise.jdx.dev/), the extension will use your local binary from PATH instead of downloading.
+
+To override the binary path manually, add this to your `settings.json`:
 
 ```json
 {


### PR DESCRIPTION
Dexter will be included in Zed's official [Elixir extension](https://github.com/zed-extensions/elixir) soon - [PR](https://github.com/zed-extensions/elixir/pull/115)

Updating docs to address it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating Zed setup guidance; no code or runtime behavior is modified.
> 
> **Overview**
> Updates `README.md` Zed setup docs to reflect Dexter being bundled in Zed’s official Elixir extension, replacing the standalone extension install steps.
> 
> Adds a `settings.json` example for enabling Dexter and disabling other Elixir language servers, and clarifies automatic binary download vs using a preinstalled `dexter` from `PATH` (with an explicit manual binary path override example).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f55729d65e2e7a4a849f175ac370a4a146b44bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->