### PR TITLE
Revert "Update Zed Extension docs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,26 +185,13 @@ lspconfig.dexter.setup({})
 
 ### Zed
 
-Dexter is included in Zed's official [Elixir extension](https://github.com/zed-extensions/elixir). No extra installation needed — just enable it in your Zed `settings.json`:
+Install the [dexter-zed](https://github.com/remoteoss/dexter-zed) extension:
 
-```json
-{
-  "languages": {
-    "Elixir": {
-      "language_servers": ["dexter", "!elixir-ls", "!expert"]
-    },
-    "HEEx": {
-      "language_servers": ["dexter", "!elixir-ls", "!expert"]
-    }
-  }
-}
-```
+1. In Zed, open **Extensions** (`Cmd+Shift+X`) and search for **"Dexter"**
+2. Click **Install**
+3. Open any Elixir file — the index builds automatically on first startup
 
-Open any Elixir file — the binary will be downloaded automatically on first startup.
-
-If you already have Dexter installed via [mise](https://mise.jdx.dev/), the extension will use your local binary from PATH instead of downloading.
-
-To override the binary path manually, add this to your `settings.json`:
+Configure the binary path in Zed's `settings.json`:
 
 ```json
 {


### PR DESCRIPTION
Reverts remoteoss/dexter#23

We'll add these back once the extension is actually merged to Zed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that doesn’t affect runtime behavior or shipped code.
> 
> **Overview**
> Updates the README’s **Zed** section to instruct users to install the standalone `dexter-zed` extension via the Extensions UI, replacing the previous claim that Dexter ships in Zed’s official Elixir extension along with the old `language_servers` JSON snippet.
> 
> Also tweaks the wording around first-run behavior (index builds on startup) and reframes the `settings.json` example as the way to configure the Dexter binary path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7feb4633d69a5ff1bc6f34d20f8a1279c6af50e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->