### PR TITLE
Update readme section for Zed extension, keep it as dev while PR is in review

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,28 @@ lspconfig.dexter.setup({})
 
 ### Zed
 
-Dexter is included in Zed's official [Elixir extension](https://github.com/zed-extensions/elixir). No extra installation needed — just enable it in your Zed `settings.json`:
+Zed support is available via a dev extension while the official Elixir extension PR is in [review](https://github.com/zed-extensions/elixir/pull/115).
+
+To install it:
+
+1. Clone the repo and checkout the branch:
+   ```bash
+   git clone https://github.com/flowerett/zed-elixir-extensions.git
+   cd zed-elixir-extensions
+   git checkout add-dexter-support
+   ```
+2. In Zed, open the command palette (`Cmd+Shift+P`) and run **zed: install dev extension**
+3. Select the cloned `zed-elixir-extensions` directory
+
+Once installed, enable it in your Zed `settings.json`:
 
 ```json
 {
   "languages": {
     "Elixir": {
+      "language_servers": ["dexter", "!elixir-ls", "!expert"]
+    },
+    "EEx": {
       "language_servers": ["dexter", "!elixir-ls", "!expert"]
     },
     "HEEx": {
@@ -199,8 +215,6 @@ Dexter is included in Zed's official [Elixir extension](https://github.com/zed-e
   }
 }
 ```
-
-Open any Elixir file — the binary will be downloaded automatically on first startup.
 
 If you already have Dexter installed via [mise](https://mise.jdx.dev/), the extension will use your local binary from PATH instead of downloading.
 


### PR DESCRIPTION
official extension is in review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates Zed installation steps and configuration; no code or runtime behavior is affected.
> 
> **Overview**
> Updates the `README.md` Zed setup section to clarify that Dexter support is currently provided via a *dev* Zed extension (pending the official Elixir extension PR) and replaces the prior install steps with instructions to clone/install the dev extension and configure `language_servers`/optional binary path in `settings.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e12442c8069f8ad9691d6a4bc12101f8099e3121. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->