### PR TITLE
docs: add LSP instructions for Helix editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,20 +238,6 @@ To override the binary path manually, add this to your `settings.json`:
 
 The emacs instructions assume you're using **use-package**.
 
-### Helix
-
-Add to your LSP configuration in `~/.config/helix/languages.toml`:
-
-```toml
-[language-server.dexter]
-command = "dexter"
-args = ["lsp"]
-
-[[language]]
-name = "elixir"
-language-servers = ["dexter"]
-```
-
 #### Eglot
 
 ##### Emacs version >= 30
@@ -299,6 +285,20 @@ language-servers = ["dexter"]
                      '("/path/to/dexter" "lsp")) ;; wherever `which dexter` points to
     :activation-fn (lsp-activate-on "elixir")
     :server-id 'dexter-elixir)))
+```
+
+### Helix
+
+Add to your LSP configuration in `~/.config/helix/languages.toml`:
+
+```toml
+[language-server.dexter]
+command = "dexter"
+args = ["lsp"]
+
+[[language]]
+name = "elixir"
+language-servers = ["dexter"]
 ```
 
 ## Why build another LSP?

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A fast, full-featured Elixir LSP optimized for large Elixir codebases.
   - [Neovim (with nvim-lspconfig — \< 0.11)](#neovim-with-nvim-lspconfig---011)
   - [Zed](#zed)
   - [Emacs](#emacs)
+  - [Helix](#helix)
 - [Why build another LSP?](#why-build-another-lsp)
 - [Performance](#performance)
 - [CLI usage](#cli-usage)
@@ -236,6 +237,20 @@ To override the binary path manually, add this to your `settings.json`:
 ### Emacs
 
 The emacs instructions assume you're using **use-package**.
+
+### Helix
+
+Add to your LSP configuration in `~/.config/helix/languages.toml`:
+
+```toml
+[language-server.dexter]
+command = "dexter"
+args = ["lsp"]
+
+[[language]]
+name = "elixir"
+language-servers = ["dexter"]
+```
 
 #### Eglot
 


### PR DESCRIPTION
This PR adds instructions on how to configure `dexter` LSP for the Helix editor.