### PR TITLE
use umbrella root formatter config when present

### DIFF
--- a/internal/lsp/formatter.go
+++ b/internal/lsp/formatter.go
@@ -285,13 +285,12 @@ func (s *Server) getFormatter(mixRoot, formatterExs string) (*formatterProcess, 
 // findFormatterConfig walks from the file's directory up to the mix root,
 // returning the path to the nearest .formatter.exs. This handles subdirectory
 // configs (e.g. config/.formatter.exs with different rules than the root).
-func findFormatterConfig(filePath, mixRoot, umbrellaRoot string) (root, formatterExs string) {
+func findFormatterConfig(filePath, mixRoot string) string {
 	dir := filepath.Dir(filePath)
-
 	for {
 		candidate := filepath.Join(dir, ".formatter.exs")
 		if _, err := os.Stat(candidate); err == nil {
-			return mixRoot, candidate
+			return candidate
 		}
 		if dir == mixRoot {
 			break
@@ -302,15 +301,7 @@ func findFormatterConfig(filePath, mixRoot, umbrellaRoot string) (root, formatte
 		}
 		dir = parent
 	}
-
-	if umbrellaRoot != "" {
-		umbrellaFormatter := filepath.Join(umbrellaRoot, ".formatter.exs")
-		if _, err := os.Stat(umbrellaFormatter); err == nil {
-			return umbrellaRoot, umbrellaFormatter
-		}
-	}
-
-	return mixRoot, filepath.Join(mixRoot, ".formatter.exs")
+	return filepath.Join(mixRoot, ".formatter.exs")
 }
 
 // formatContent tries the persistent formatter, falling back to mix format.
@@ -319,12 +310,12 @@ func findFormatterConfig(filePath, mixRoot, umbrellaRoot string) (root, formatte
 //   - <5s old: wait for the process to become ready, then use it
 //   - 5s–30s old: don't wait, fall back to mix format immediately
 //   - >30s old and still not ready: kill and restart the stuck process
-func (s *Server) formatContent(ctx context.Context, mixRoot, umbrellaRoot, path, content string) (string, error) {
-	root, formatterExs := findFormatterConfig(path, mixRoot, umbrellaRoot)
-	fp, err := s.getFormatter(root, formatterExs)
+func (s *Server) formatContent(ctx context.Context, mixRoot, path, content string) (string, error) {
+	formatterExs := findFormatterConfig(path, mixRoot)
+	fp, err := s.getFormatter(mixRoot, formatterExs)
 	if err != nil {
 		log.Printf("Formatting: persistent formatter unavailable, falling back to mix format: %v", err)
-		return s.formatWithMixFormat(ctx, root, path, content)
+		return s.formatWithMixFormat(ctx, mixRoot, path, content)
 	}
 
 	// Check if already ready (non-blocking)

--- a/internal/lsp/formatter.go
+++ b/internal/lsp/formatter.go
@@ -285,12 +285,13 @@ func (s *Server) getFormatter(mixRoot, formatterExs string) (*formatterProcess, 
 // findFormatterConfig walks from the file's directory up to the mix root,
 // returning the path to the nearest .formatter.exs. This handles subdirectory
 // configs (e.g. config/.formatter.exs with different rules than the root).
-func findFormatterConfig(filePath, mixRoot string) string {
+func findFormatterConfig(filePath, mixRoot, umbrellaRoot string) (root, formatterExs string) {
 	dir := filepath.Dir(filePath)
+
 	for {
 		candidate := filepath.Join(dir, ".formatter.exs")
 		if _, err := os.Stat(candidate); err == nil {
-			return candidate
+			return mixRoot, candidate
 		}
 		if dir == mixRoot {
 			break
@@ -301,7 +302,15 @@ func findFormatterConfig(filePath, mixRoot string) string {
 		}
 		dir = parent
 	}
-	return filepath.Join(mixRoot, ".formatter.exs")
+
+	if umbrellaRoot != "" {
+		umbrellaFormatter := filepath.Join(umbrellaRoot, ".formatter.exs")
+		if _, err := os.Stat(umbrellaFormatter); err == nil {
+			return umbrellaRoot, umbrellaFormatter
+		}
+	}
+
+	return mixRoot, filepath.Join(mixRoot, ".formatter.exs")
 }
 
 // formatContent tries the persistent formatter, falling back to mix format.
@@ -310,12 +319,12 @@ func findFormatterConfig(filePath, mixRoot string) string {
 //   - <5s old: wait for the process to become ready, then use it
 //   - 5s–30s old: don't wait, fall back to mix format immediately
 //   - >30s old and still not ready: kill and restart the stuck process
-func (s *Server) formatContent(ctx context.Context, mixRoot, path, content string) (string, error) {
-	formatterExs := findFormatterConfig(path, mixRoot)
-	fp, err := s.getFormatter(mixRoot, formatterExs)
+func (s *Server) formatContent(ctx context.Context, mixRoot, umbrellaRoot, path, content string) (string, error) {
+	root, formatterExs := findFormatterConfig(path, mixRoot, umbrellaRoot)
+	fp, err := s.getFormatter(root, formatterExs)
 	if err != nil {
 		log.Printf("Formatting: persistent formatter unavailable, falling back to mix format: %v", err)
-		return s.formatWithMixFormat(ctx, mixRoot, path, content)
+		return s.formatWithMixFormat(ctx, root, path, content)
 	}
 
 	// Check if already ready (non-blocking)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -438,9 +438,9 @@ func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocume
 	path := uriToPath(params.TextDocument.URI)
 	if path != "" && isFormattableFile(path) && s.isProjectFile(path) && !s.isDepsFile(path) {
 		go func() {
-			if mixRoot, umbrellaRoot := findMixRoot(filepath.Dir(path)); mixRoot != "" {
-				root, formatterExs := findFormatterConfig(path, mixRoot, umbrellaRoot)
-				_, _ = s.getFormatter(root, formatterExs)
+			if mixRoot := findMixRoot(s.projectRoot, filepath.Dir(path)); mixRoot != "" {
+				formatterExs := findFormatterConfig(path, mixRoot)
+				_, _ = s.getFormatter(mixRoot, formatterExs)
 			}
 		}()
 	}
@@ -737,25 +737,16 @@ func findDexterRoot(path string) string {
 	return path
 }
 
-// findMixRoot walks up from dir looking for the nearest mix.exs.
-func findMixRoot(dir string) (appRoot, umbrellaRoot string) {
-	isMixRoot := func(path string) bool {
-		_, err := os.Stat(filepath.Join(path, "mix.exs"))
-		return err == nil
-	}
-
+// findMixRoot walks up from dir looking for the mix.exs closest to the project root.
+// Handles standard apps (single mix.exs), umbrella apps (root-level mix.exs), and monorepos.
+func findMixRoot(projectRoot, dir string) (mixRoot string) {
 	for {
-		if isMixRoot(dir) {
-			// found nearest mix.exs, check if we're in an umbrella app
-			umbrellaRoot = filepath.Dir(filepath.Dir(dir))
-			if isMixRoot(umbrellaRoot) {
-				return dir, umbrellaRoot
-			}
-			return dir, ""
+		if _, err := os.Stat(filepath.Join(dir, "mix.exs")); err == nil {
+			mixRoot = dir
 		}
 		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", ""
+		if parent == dir || dir == projectRoot {
+			return
 		}
 		dir = parent
 	}
@@ -2594,7 +2585,7 @@ func (s *Server) Formatting(ctx context.Context, params *protocol.DocumentFormat
 		return nil, nil
 	}
 
-	mixRoot, umbrellaRoot := findMixRoot(filepath.Dir(path))
+	mixRoot := findMixRoot(s.projectRoot, filepath.Dir(path))
 	if mixRoot == "" {
 		return nil, nil
 	}
@@ -2602,7 +2593,7 @@ func (s *Server) Formatting(ctx context.Context, params *protocol.DocumentFormat
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	formatted, err := s.formatContent(ctx, mixRoot, umbrellaRoot, path, text)
+	formatted, err := s.formatContent(ctx, mixRoot, path, text)
 	if err != nil {
 		var formatErr *FormatError
 		if errors.As(err, &formatErr) {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -438,9 +438,9 @@ func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocume
 	path := uriToPath(params.TextDocument.URI)
 	if path != "" && isFormattableFile(path) && s.isProjectFile(path) && !s.isDepsFile(path) {
 		go func() {
-			if mixRoot := findMixRoot(filepath.Dir(path)); mixRoot != "" {
-				formatterExs := findFormatterConfig(path, mixRoot)
-				_, _ = s.getFormatter(mixRoot, formatterExs)
+			if mixRoot, umbrellaRoot := findMixRoot(filepath.Dir(path)); mixRoot != "" {
+				root, formatterExs := findFormatterConfig(path, mixRoot, umbrellaRoot)
+				_, _ = s.getFormatter(root, formatterExs)
 			}
 		}()
 	}
@@ -738,14 +738,24 @@ func findDexterRoot(path string) string {
 }
 
 // findMixRoot walks up from dir looking for the nearest mix.exs.
-func findMixRoot(dir string) string {
+func findMixRoot(dir string) (appRoot, umbrellaRoot string) {
+	isMixRoot := func(path string) bool {
+		_, err := os.Stat(filepath.Join(path, "mix.exs"))
+		return err == nil
+	}
+
 	for {
-		if _, err := os.Stat(filepath.Join(dir, "mix.exs")); err == nil {
-			return dir
+		if isMixRoot(dir) {
+			// found nearest mix.exs, check if we're in an umbrella app
+			umbrellaRoot = filepath.Dir(filepath.Dir(dir))
+			if isMixRoot(umbrellaRoot) {
+				return dir, umbrellaRoot
+			}
+			return dir, ""
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return ""
+			return "", ""
 		}
 		dir = parent
 	}
@@ -2584,7 +2594,7 @@ func (s *Server) Formatting(ctx context.Context, params *protocol.DocumentFormat
 		return nil, nil
 	}
 
-	mixRoot := findMixRoot(filepath.Dir(path))
+	mixRoot, umbrellaRoot := findMixRoot(filepath.Dir(path))
 	if mixRoot == "" {
 		return nil, nil
 	}
@@ -2592,7 +2602,7 @@ func (s *Server) Formatting(ctx context.Context, params *protocol.DocumentFormat
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	formatted, err := s.formatContent(ctx, mixRoot, path, text)
+	formatted, err := s.formatContent(ctx, mixRoot, umbrellaRoot, path, text)
 	if err != nil {
 		var formatErr *FormatError
 		if errors.As(err, &formatErr) {

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2589,21 +2589,21 @@ func TestFindMixRoot(t *testing.T) {
 	}
 
 	t.Run("finds nearest mix.exs from project lib dir", func(t *testing.T) {
-		got := findMixRoot(filepath.Join(myApp, "lib"))
+		got, _ := findMixRoot(filepath.Join(myApp, "lib"))
 		if got != myApp {
 			t.Errorf("expected %s, got %s", myApp, got)
 		}
 	})
 
 	t.Run("finds mix.exs in same directory", func(t *testing.T) {
-		got := findMixRoot(myApp)
+		got, _ := findMixRoot(myApp)
 		if got != myApp {
 			t.Errorf("expected %s, got %s", myApp, got)
 		}
 	})
 
 	t.Run("each project resolves to its own mix root", func(t *testing.T) {
-		got := findMixRoot(filepath.Join(otherProject, "lib"))
+		got, _ := findMixRoot(filepath.Join(otherProject, "lib"))
 		if got != otherProject {
 			t.Errorf("expected %s, got %s", otherProject, got)
 		}
@@ -2611,9 +2611,40 @@ func TestFindMixRoot(t *testing.T) {
 
 	t.Run("returns empty when no mix.exs exists", func(t *testing.T) {
 		empty := t.TempDir()
-		got := findMixRoot(empty)
+		got, _ := findMixRoot(empty)
 		if got != "" {
 			t.Errorf("expected empty string, got %s", got)
+		}
+	})
+}
+
+func TestFindMixUmbrellaRoot(t *testing.T) {
+	root := t.TempDir()
+
+	// Create an umbrella structure (with root mix.exs):
+	//   root/mix.exs
+	//   root/apps/a/mix.exs
+	//   root/apps/a/lib/
+	rootMix := filepath.Join(root, "mix.exs")
+	if err := os.WriteFile(rootMix, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	app := filepath.Join(root, "apps", "a")
+	if err := os.MkdirAll(filepath.Join(app, "lib"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	appMix := filepath.Join(app, "mix.exs")
+	if err := os.WriteFile(appMix, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("finds nearest mix.exs and umbrella mix.exs from project lib dir", func(t *testing.T) {
+		gotApp, gotUmbrella := findMixRoot(filepath.Join(app, "lib"))
+		if gotApp != app {
+			t.Errorf("expected %s, got %s", app, gotApp)
+		}
+		if gotUmbrella != root {
+			t.Errorf("expected %s, got %s", root, gotUmbrella)
 		}
 	})
 }
@@ -2730,8 +2761,8 @@ func TestFormatter_RestartAfterCrash(t *testing.T) {
 	}
 
 	// Kill the persistent process
-	mixRoot := findMixRoot(filepath.Dir(filePath))
-	formatterExs := findFormatterConfig(filePath, mixRoot)
+	mixRoot, umbrellaRoot := findMixRoot(filepath.Dir(filePath))
+	formatterExs, _ := findFormatterConfig(filePath, mixRoot, umbrellaRoot)
 	server.formattersMu.Lock()
 	if fp, ok := server.formatters[formatterExs]; ok {
 		fp.Close()

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2589,21 +2589,21 @@ func TestFindMixRoot(t *testing.T) {
 	}
 
 	t.Run("finds nearest mix.exs from project lib dir", func(t *testing.T) {
-		got, _ := findMixRoot(filepath.Join(myApp, "lib"))
+		got := findMixRoot(root, filepath.Join(myApp, "lib"))
 		if got != myApp {
 			t.Errorf("expected %s, got %s", myApp, got)
 		}
 	})
 
 	t.Run("finds mix.exs in same directory", func(t *testing.T) {
-		got, _ := findMixRoot(myApp)
+		got := findMixRoot(root, myApp)
 		if got != myApp {
 			t.Errorf("expected %s, got %s", myApp, got)
 		}
 	})
 
 	t.Run("each project resolves to its own mix root", func(t *testing.T) {
-		got, _ := findMixRoot(filepath.Join(otherProject, "lib"))
+		got := findMixRoot(root, filepath.Join(otherProject, "lib"))
 		if got != otherProject {
 			t.Errorf("expected %s, got %s", otherProject, got)
 		}
@@ -2611,7 +2611,7 @@ func TestFindMixRoot(t *testing.T) {
 
 	t.Run("returns empty when no mix.exs exists", func(t *testing.T) {
 		empty := t.TempDir()
-		got, _ := findMixRoot(empty)
+		got := findMixRoot(root, empty)
 		if got != "" {
 			t.Errorf("expected empty string, got %s", got)
 		}
@@ -2638,13 +2638,10 @@ func TestFindMixUmbrellaRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("finds nearest mix.exs and umbrella mix.exs from project lib dir", func(t *testing.T) {
-		gotApp, gotUmbrella := findMixRoot(filepath.Join(app, "lib"))
-		if gotApp != app {
-			t.Errorf("expected %s, got %s", app, gotApp)
-		}
-		if gotUmbrella != root {
-			t.Errorf("expected %s, got %s", root, gotUmbrella)
+	t.Run("finds nearest-to-root mix.exs from project lib dir", func(t *testing.T) {
+		got := findMixRoot(root, filepath.Join(app, "lib"))
+		if got != root {
+			t.Errorf("expected %s, got %s", root, got)
 		}
 	})
 }
@@ -2761,8 +2758,8 @@ func TestFormatter_RestartAfterCrash(t *testing.T) {
 	}
 
 	// Kill the persistent process
-	mixRoot, umbrellaRoot := findMixRoot(filepath.Dir(filePath))
-	formatterExs, _ := findFormatterConfig(filePath, mixRoot, umbrellaRoot)
+	mixRoot := findMixRoot(server.projectRoot, filepath.Dir(filePath))
+	formatterExs := findFormatterConfig(filePath, mixRoot)
 	server.formattersMu.Lock()
 	if fp, ok := server.formatters[formatterExs]; ok {
 		fp.Close()


### PR DESCRIPTION
Closes #34.

Given this file tree:

```
| mix.exs
| .formatter.exs
/ apps
  / app_web
    | mix.exs
    / lib
      | component.ex
```

When formatting `apps/app_web/lib/component.ex`, the umbrella root `.formatter.exs` should be used.

I'm not confident that the approach I took to solve this, namely having `findMixRoot` return `(appRoot, umbrellaRoot string)`, is the best. It requires passing around both the app root and umbrella roots whenever resolving a formatter. It may be easier to identify the correct formatter file earlier and just pass that around instead.