### PR TITLE
docs: set defaultFormatter to correct value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ To enable format-on-save, update your VS Code settings:
   "[elixir]": {
       "editor.formatOnSave": true,
       // you may need to set Dexter as your default Elixir formatter, depending on your setup
-      "editor.defaultFormatter": "remoteoss.dexter-lsp"
+      "editor.defaultFormatter": "remote-com-oss.dexter-lsp"
   },
   "[phoenix-heex]": { "editor.formatOnSave": true }
 }

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ But if Dexter is not on your `PATH`, set the binary path in your editor settings
 }
 ```
 
-To enable format-on-save, update your VS Code settings:
+To enable format-on-save, update your VS Code/Cursor settings:
 
 ```json
 // global in your editor
@@ -132,7 +132,7 @@ To enable format-on-save, update your VS Code settings:
   "[elixir]": {
       "editor.formatOnSave": true,
       // you may need to set Dexter as your default Elixir formatter, depending on your setup
-      "editor.defaultFormatter": "remote-com-oss.dexter-lsp"
+      "editor.defaultFormatter": "remoteoss.dexter-lsp" // "remote-com-oss.dexter-lsp" for Cursor
   },
   "[phoenix-heex]": { "editor.formatOnSave": true }
 }


### PR DESCRIPTION
Formatting wasn't working and after checking the settings, the current value in the README causes a "Value not accepted" warning. The auto-suggest shows `remote-com-oss.dexter-lsp` which seems to work.

<img width="1143" height="40" alt="image" src="https://github.com/user-attachments/assets/5a0d2140-fd19-4529-ad94-c2f6af17e44c" />
