### PR TITLE
docs: simplify Zed setup now that extension is in registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,19 +217,7 @@ lspconfig.dexter.setup({})
 
 ### Zed
 
-Zed support is available via a **dev extension** while the update for built-in [extension registry](https://github.com/zed-industries/extensions/pull/5624) and [documentation](https://github.com/zed-industries/zed/pull/53793) is being merged.
-
-To install it:
-
-1. Clone the official extension repo:
-   ```bash
-   git clone https://github.com/zed-extensions/elixir.git
-   cd elixir
-   ```
-2. In Zed, open the command palette (`Cmd+Shift+P`) and run **zed: install dev extension**
-3. Select the cloned `elixir` directory
-
-Once installed, enable it in your Zed `settings.json`:
+Enable Dexter in your Zed `settings.json`:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ lspconfig.dexter.setup({})
 
 ### Zed
 
-Enable Dexter in your Zed `settings.json`:
+See the [Zed docs](https://zed.dev/docs/languages/elixir#using-dexter) for full details. Enable Dexter in your Zed `settings.json`:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Removes the dev extension workaround (clone + install dev extension steps) from the Zed section of the README
- The built-in extension registry and documentation PRs have now merged, so only the `settings.json` configuration is needed

## Changes

The Zed section previously read:

> Zed support is available via a **dev extension** while the update for built-in extension registry and documentation is being merged.

Along with manual clone/install steps. Those are now replaced with a single line directing users straight to the `settings.json` config.