### PR TITLE
feat: add Claude Code marketplace and dexter-lsp plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "dexter",
+  "owner": {
+    "name": "remoteoss",
+    "url": "https://github.com/remoteoss"
+  },
+  "plugins": [
+    {
+      "name": "dexter-lsp",
+      "source": "./plugins/dexter-lsp",
+      "description": "Dexter language server for Elixir (.ex, .exs, .heex)"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -334,51 +334,11 @@ language-servers = ["dexter"]
 }
 ```
 
-**1. Create the plugin manifest:**
+**Install:**
 
 ```sh
-mkdir -p ~/.claude/plugins/local/.claude-plugin
-mkdir -p ~/.claude/plugins/local/plugins/dexter-lsp
-```
-
-Create `~/.claude/plugins/local/.claude-plugin/marketplace.json`. If the file already exists, add the `dexter-lsp` entry to the `plugins` array.
-
-```json
-{
-  "$schema": "https://claude.ai/schemas/marketplace.json",
-  "name": "local",
-  "description": "Local plugins",
-  "owner": { "name": "local" },
-  "plugins": [
-    {
-      "name": "dexter-lsp",
-      "description": "Dexter language server for Elixir (.ex, .exs, .heex)",
-      "version": "1.0.0",
-      "author": { "name": "local" },
-      "source": "./plugins/dexter-lsp",
-      "category": "development",
-      "strict": false,
-      "lspServers": {
-        "dexter": {
-          "command": "dexter",
-          "args": ["lsp"],
-          "extensionToLanguage": {
-            ".ex": "elixir",
-            ".exs": "elixir",
-            ".heex": "phoenix-heex"
-          }
-        }
-      }
-    }
-  ]
-}
-```
-
-**2. Register the marketplace and install:**
-
-```sh
-claude plugin marketplace add ~/.claude/plugins/local
-claude plugin install dexter-lsp@local
+claude plugin marketplace add remoteoss/dexter
+claude plugin install dexter-lsp@dexter
 ```
 
 That's it. Open an Elixir project in Claude Code and Dexter will handle go-to-definition, hover documentation, find references, and more.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A fast, full-featured Elixir LSP optimized for large Elixir codebases.
     - [Configuring format on save](#configuring-format-on-save)
   - [Neovim (with nvim-lspconfig — \< 0.11)](#neovim-with-nvim-lspconfig---011)
   - [Zed](#zed)
+  - [Claude Code](#claude-code)
   - [Emacs](#emacs)
     - [Eglot](#eglot)
       - [Emacs version \>= 30](#emacs-version--30)
@@ -318,6 +319,69 @@ args = ["lsp"]
 name = "elixir"
 language-servers = ["dexter"]
 ```
+
+### Claude Code
+
+[Claude Code](https://claude.ai/code) supports Dexter as an Elixir LSP via its plugin system, enabling go-to-definition, hover docs, find references, and more when working on `.ex`, `.exs`, and `.heex` files.
+
+**Prerequisites:** The LSP tool must be enabled. Add this to your `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ENABLE_LSP_TOOL": "1"
+  }
+}
+```
+
+**1. Create the plugin manifest:**
+
+```sh
+mkdir -p ~/.claude/plugins/local/.claude-plugin
+mkdir -p ~/.claude/plugins/local/plugins/dexter-lsp
+```
+
+Create `~/.claude/plugins/local/.claude-plugin/marketplace.json`. If the file already exists, add the `dexter-lsp` entry to the `plugins` array.
+
+```json
+{
+  "$schema": "https://claude.ai/schemas/marketplace.json",
+  "name": "local",
+  "description": "Local plugins",
+  "owner": { "name": "local" },
+  "plugins": [
+    {
+      "name": "dexter-lsp",
+      "description": "Dexter language server for Elixir (.ex, .exs, .heex)",
+      "version": "1.0.0",
+      "author": { "name": "local" },
+      "source": "./plugins/dexter-lsp",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "dexter": {
+          "command": "dexter",
+          "args": ["lsp"],
+          "extensionToLanguage": {
+            ".ex": "elixir",
+            ".exs": "elixir",
+            ".heex": "phoenix-heex"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+**2. Register the marketplace and install:**
+
+```sh
+claude plugin marketplace add ~/.claude/plugins/local
+claude plugin install dexter-lsp@local
+```
+
+That's it. Open an Elixir project in Claude Code and Dexter will handle go-to-definition, hover documentation, find references, and more.
 
 ## Why build another LSP?
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -294,6 +294,26 @@ func (s *Server) notifyOTPMismatch(stderr string) {
 
 // === LSP Lifecycle ===
 
+// coerceBool accepts a JSON bool or a JSON string ("true"/"false"/"1"/"0"…).
+// Claude Code plugin template substitution (e.g. "${user_config.debug}") produces
+// a string, not a bool, so we accept both forms.
+func coerceBool(v interface{}) (bool, bool) {
+	switch x := v.(type) {
+	case bool:
+		return x, true
+	case string:
+		if x == "" {
+			return false, false
+		}
+		b, err := strconv.ParseBool(x)
+		if err != nil {
+			return false, false
+		}
+		return b, true
+	}
+	return false, false
+}
+
 func (s *Server) Initialize(ctx context.Context, params *protocol.InitializeParams) (*protocol.InitializeResult, error) {
 	// Note: unlike cmd/main.go, the LSP deliberately does NOT pass "mix.exs"
 	// to store.FindProjectRoot. In a monorepo we want to anchor on
@@ -315,13 +335,13 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 
 	var explicitStdlibPath string
 	if opts, ok := params.InitializationOptions.(map[string]interface{}); ok {
-		if v, ok := opts["followDelegates"].(bool); ok {
+		if v, ok := coerceBool(opts["followDelegates"]); ok {
 			s.followDelegates = v
 		}
 		if v, ok := opts["stdlibPath"].(string); ok {
 			explicitStdlibPath = v
 		}
-		if v, ok := opts["debug"].(bool); ok {
+		if v, ok := coerceBool(opts["debug"]); ok {
 			s.debug = v
 		}
 	}

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -231,25 +231,52 @@ end`)
 	})
 }
 
-func TestServer_InitializationOptions_FollowDelegates(t *testing.T) {
-	server, cleanup := setupTestServer(t)
-	defer cleanup()
+func TestServer_InitializationOptions(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		server, cleanup := setupTestServer(t)
+		defer cleanup()
+		if !server.followDelegates {
+			t.Error("followDelegates should default to true")
+		}
+		if server.debug {
+			t.Error("debug should default to false")
+		}
+	})
 
-	// Default should be true
-	if !server.followDelegates {
-		t.Error("followDelegates should default to true")
+	// Claude Code plugin template substitution yields strings, not booleans.
+	// Verify coerceBool handles both native bools and string-encoded bools.
+	cases := []struct {
+		name             string
+		opts             map[string]interface{}
+		wantFollowDel    bool
+		wantDebug        bool
+	}{
+		{"bool true/false", map[string]interface{}{"followDelegates": false, "debug": true}, false, true},
+		{"string true/false", map[string]interface{}{"followDelegates": "false", "debug": "true"}, false, true},
+		{"string 1/0", map[string]interface{}{"followDelegates": "0", "debug": "1"}, false, true},
+		{"empty string leaves default", map[string]interface{}{"followDelegates": "", "debug": ""}, true, false},
+		{"unsupported type leaves default", map[string]interface{}{"followDelegates": 1, "debug": 0}, true, false},
 	}
 
-	// Simulate initializationOptions with followDelegates=false
-	opts := map[string]interface{}{
-		"followDelegates": false,
-	}
-	if v, ok := opts["followDelegates"].(bool); ok {
-		server.followDelegates = v
-	}
-
-	if server.followDelegates {
-		t.Error("followDelegates should be false after setting via initializationOptions")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server, cleanup := setupTestServer(t)
+			defer cleanup()
+			dir := t.TempDir()
+			_, err := server.Initialize(context.Background(), &protocol.InitializeParams{
+				RootURI:               protocol.DocumentURI("file://" + dir),
+				InitializationOptions: tc.opts,
+			})
+			if err != nil {
+				t.Fatalf("Initialize returned error: %v", err)
+			}
+			if server.followDelegates != tc.wantFollowDel {
+				t.Errorf("followDelegates: got %v, want %v", server.followDelegates, tc.wantFollowDel)
+			}
+			if server.debug != tc.wantDebug {
+				t.Errorf("debug: got %v, want %v", server.debug, tc.wantDebug)
+			}
+		})
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -246,10 +246,10 @@ func TestServer_InitializationOptions(t *testing.T) {
 	// Claude Code plugin template substitution yields strings, not booleans.
 	// Verify coerceBool handles both native bools and string-encoded bools.
 	cases := []struct {
-		name             string
-		opts             map[string]interface{}
-		wantFollowDel    bool
-		wantDebug        bool
+		name          string
+		opts          map[string]interface{}
+		wantFollowDel bool
+		wantDebug     bool
 	}{
 		{"bool true/false", map[string]interface{}{"followDelegates": false, "debug": true}, false, true},
 		{"string true/false", map[string]interface{}{"followDelegates": "false", "debug": "true"}, false, true},

--- a/plugins/dexter-lsp/.claude-plugin/plugin.json
+++ b/plugins/dexter-lsp/.claude-plugin/plugin.json
@@ -20,7 +20,6 @@
         ".exs": "elixir",
         ".heex": "phoenix-heex"
       },
-      "restartOnCrash": true,
       "initializationOptions": {
         "followDelegates": "${user_config.follow_delegates}",
         "debug": "${user_config.debug}"

--- a/plugins/dexter-lsp/.claude-plugin/plugin.json
+++ b/plugins/dexter-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "dexter-lsp",
+  "description": "Dexter language server for Elixir (.ex, .exs, .heex)",
+  "version": "0.6.0",
+  "author": {
+    "name": "remoteoss",
+    "url": "https://github.com/remoteoss"
+  },
+  "homepage": "https://github.com/remoteoss/dexter",
+  "repository": "https://github.com/remoteoss/dexter",
+  "license": "MIT",
+  "keywords": ["elixir", "lsp", "dexter", "phoenix", "heex"],
+  "lspServers": {
+    "dexter": {
+      "command": "dexter",
+      "args": ["lsp"],
+      "extensionToLanguage": {
+        ".ex": "elixir",
+        ".exs": "elixir",
+        ".heex": "phoenix-heex"
+      },
+      "restartOnCrash": true,
+      "initializationOptions": {
+        "followDelegates": "${user_config.follow_delegates}",
+        "debug": "${user_config.debug}"
+      }
+    }
+  },
+  "userConfig": {
+    "follow_delegates": {
+      "type": "boolean",
+      "title": "Follow delegates",
+      "description": "Jump through defdelegate to the target function definition",
+      "default": true
+    },
+    "debug": {
+      "type": "boolean",
+      "title": "Debug logging",
+      "description": "Enable verbose LSP logging to stderr",
+      "default": false
+    }
+  }
+}

--- a/plugins/dexter-lsp/.claude-plugin/plugin.json
+++ b/plugins/dexter-lsp/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "dexter-lsp",
   "description": "Dexter language server for Elixir (.ex, .exs, .heex)",
-  "version": "0.6.0",
+  "version": "0.1.0",
   "author": {
     "name": "remoteoss",
     "url": "https://github.com/remoteoss"


### PR DESCRIPTION
## Summary

Turns the dexter repo into a Claude Code marketplace, so users can install Dexter as their Elixir LSP in Claude Code with just two commands:

```sh
claude plugin marketplace add remoteoss/dexter
claude plugin install dexter-lsp@dexter
```

### Changes

- `.claude-plugin/marketplace.json` — makes this repo a Claude Code marketplace named `dexter`
- `plugins/dexter-lsp/.claude-plugin/plugin.json` — plugin manifest that wires up `dexter lsp` for `.ex`, `.exs`, and `.heex` files, with `followDelegates` and `debug` exposed as user-configurable options
- `README.md` — adds a Claude Code section to the editor setup docs

### How it works

Claude Code's LSP tool supports a plugin system. The `lspServers` entry in `plugin.json` tells Claude Code to spawn `dexter lsp` when opening Elixir files, giving it go-to-definition, hover docs, find references, workspace symbols, and more.

## Test plan

- [ ] `claude plugin marketplace add remoteoss/dexter` succeeds
- [ ] `claude plugin install dexter-lsp@dexter` succeeds
- [ ] Open an Elixir project — LSP tool resolves hover and go-to-definition on `.ex` files
- [ ] `userConfig` prompts appear for `followDelegates` and `debug` on install

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Plugin manifests, documentation, and defensive init-option parsing with expanded tests; no changes to indexing or core LSP behavior beyond config parsing.
> 
> **Overview**
> This PR turns the **dexter** repo into a **Claude Code** marketplace and ships a **dexter-lsp** plugin that runs `dexter lsp` for `.ex`, `.exs`, and `.heex`, with user settings for **followDelegates** and **debug**.
> 
> The LSP server now accepts **boolean initialization options as strings** (via `coerceBool`), because Claude Code’s `${user_config.*}` substitution sends strings instead of JSON booleans. Tests cover bools, `"true"`/`"false"`, `"1"`/`"0"`, and invalid values.
> 
> **README** adds a Claude Code editor section: enable `ENABLE_LSP_TOOL`, then `claude plugin marketplace add` / `plugin install`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a339ee17ce7d15b53d0fbde0ba636c69168b0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->