### PR TITLE
Add lazy-loading and LRU cache for context-based lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ Dexter reads `initializationOptions` from your editor configuration:
 - **`followDelegates`** (boolean, default: `true`): follow `defdelegate` targets on lookup.
 - **`stdlibPath`** (string): override the Elixir stdlib directory to index. Defaults to auto-detection; use this if your install is non-standard.
 - **`debug`** (boolean, default: `false`): enable verbose logging to stderr. Logs timing and resolution details for every definition, hover, references, and rename request. Can also be enabled via the `DEXTER_DEBUG=true` environment variable.
+- **`maxTransientDocuments`** (integer, default: `50`): cap on how many lazily-loaded buffers the server retains in memory. When an LSP client (e.g. Claude Code) queries a file it never opened via `didOpen`, dexter reads it from disk and caches it. Editor-owned buffers are unaffected; only disk-loaded entries are subject to LRU eviction. Set to `0` to disable transient caching.
 
 ## Index database location (.dexter/)
 

--- a/internal/lsp/documents.go
+++ b/internal/lsp/documents.go
@@ -211,8 +211,16 @@ func (ds *DocumentStore) GetOrLoad(uri string) (string, bool) {
 	// Re-check: another goroutine may have populated this URI (via Set
 	// or a concurrent GetOrLoad) while we were reading from disk. If so,
 	// prefer the existing entry - Set wins by definition; a concurrent
-	// transient load is equivalent to ours.
+	// transient load is equivalent to ours. Bump the LRU on the way out
+	// so this access registers as recency-of-use, matching the fast-path
+	// behavior above; without this, racing slow-path callers wouldn't
+	// keep the entry warm even though they just used it.
 	if existing, ok := ds.docs[uri]; ok {
+		if existing.transient {
+			if elem, ok := ds.transientIdx[uri]; ok {
+				ds.transientList.MoveToFront(elem)
+			}
+		}
 		return existing.text, true
 	}
 

--- a/internal/lsp/documents.go
+++ b/internal/lsp/documents.go
@@ -1,40 +1,86 @@
 package lsp
 
 import (
+	"container/list"
+	"os"
+	"strings"
 	"sync"
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 	tree_sitter_elixir "github.com/tree-sitter/tree-sitter-elixir/bindings/go"
+	"go.lsp.dev/protocol"
 
 	"github.com/remoteoss/dexter/internal/parser"
 )
 
+// defaultMaxTransient caps how many disk-loaded buffers may live in the
+// store concurrently. Editor-owned buffers (added via Set) are never counted
+// against this cap.
+const defaultMaxTransient = 50
+
 type cachedDoc struct {
 	text       string
 	tree       *tree_sitter.Tree
-	src        []byte         // source bytes the tree references — must stay alive
+	src        []byte         // source bytes the tree references - must stay alive
 	tokens     []parser.Token // cached tokenizer output
 	tokSrc     []byte         // source bytes for tokens
 	lineStarts []int          // byte offset of each line start (from TokenizeFull)
+	// transient is true for entries loaded from disk via GetOrLoad - i.e.
+	// no editor sent didOpen for this URI. These entries are tracked in an
+	// LRU and evicted once the transient cap is reached. Editor-owned
+	// entries (created via Set) are never transient and never evicted.
+	transient bool
 }
 
 // DocumentStore tracks the text content of open buffers and caches
 // tree-sitter parse trees for each document. All access is serialized
 // through a single RWMutex: reads (Get) take RLock, writes and parsing
 // (Set, Close, GetTree) take Lock.
+//
+// In addition to editor-managed buffers (populated by Set on didOpen /
+// didChange), DocumentStore can lazily load buffers from disk via
+// GetOrLoad. Disk-loaded entries are marked transient and tracked in an
+// LRU list so that AI tools that don't drive a didOpen/didClose lifecycle
+// (e.g. Claude Code) can still query references/hover/definition without
+// causing unbounded memory growth.
 type DocumentStore struct {
 	mu     sync.RWMutex
 	docs   map[string]*cachedDoc
 	parser *tree_sitter.Parser
+
+	// LRU bookkeeping for transient (disk-loaded) entries only. The list
+	// holds URIs in access-order, newest at the front. transientIdx maps
+	// URI → its list element for O(1) move/remove.
+	transientList *list.List
+	transientIdx  map[string]*list.Element
+	maxTransient  int
 }
 
 func NewDocumentStore() *DocumentStore {
 	p := tree_sitter.NewParser()
 	_ = p.SetLanguage(tree_sitter.NewLanguage(tree_sitter_elixir.Language()))
 	return &DocumentStore{
-		docs:   make(map[string]*cachedDoc),
-		parser: p,
+		docs:          make(map[string]*cachedDoc),
+		parser:        p,
+		transientList: list.New(),
+		transientIdx:  make(map[string]*list.Element),
+		maxTransient:  defaultMaxTransient,
 	}
+}
+
+// SetMaxTransient updates the cap on disk-loaded (transient) entries and
+// evicts any excess immediately. A cap of 0 disables transient caching —
+// disk-loaded entries are inserted and immediately evicted, so the store
+// still serves the read but never retains it. Editor-owned entries are
+// never affected. Negative values are clamped to 0.
+func (ds *DocumentStore) SetMaxTransient(n int) {
+	if n < 0 {
+		n = 0
+	}
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	ds.maxTransient = n
+	ds.evictTransientLocked()
 }
 
 func (ds *DocumentStore) Set(uri string, text string) {
@@ -43,6 +89,8 @@ func (ds *DocumentStore) Set(uri string, text string) {
 	if doc, ok := ds.docs[uri]; ok && doc.tree != nil {
 		doc.tree.Close()
 	}
+	// Editor took ownership of this URI - drop any LRU tracking for it.
+	ds.removeFromLRULocked(uri)
 	ds.docs[uri] = &cachedDoc{text: text}
 }
 
@@ -52,6 +100,7 @@ func (ds *DocumentStore) Close(uri string) {
 	if doc, ok := ds.docs[uri]; ok && doc.tree != nil {
 		doc.tree.Close()
 	}
+	ds.removeFromLRULocked(uri)
 	delete(ds.docs, uri)
 }
 
@@ -65,6 +114,8 @@ func (ds *DocumentStore) CloseAll() {
 		}
 	}
 	ds.docs = nil
+	ds.transientList = nil
+	ds.transientIdx = nil
 	ds.parser.Close()
 }
 
@@ -76,6 +127,107 @@ func (ds *DocumentStore) Get(uri string) (string, bool) {
 		return "", false
 	}
 	return doc.text, true
+}
+
+// GetOrLoad returns the text for the given URI, falling back to a disk
+// read if no editor has opened the document. Disk-loaded entries are
+// marked transient and tracked in an LRU; if the transient population
+// exceeds the cap, the least-recently-used transient entry is evicted.
+//
+// Returns ("", false) if the URI does not resolve to a readable file on
+// disk (e.g. non-file:// URIs, missing files, permission errors).
+//
+// Editor-owned entries (added via Set) are never evicted and are not
+// reordered in the LRU - only transient entries participate.
+func (ds *DocumentStore) GetOrLoad(uri string) (string, bool) {
+	// Fast path: lookup under RLock. We avoid the LRU bump here so
+	// repeated hits on editor-owned buffers don't contend on the write
+	// lock at all.
+	ds.mu.RLock()
+	if doc, ok := ds.docs[uri]; ok {
+		text := doc.text
+		isTransient := doc.transient
+		ds.mu.RUnlock()
+		if isTransient {
+			ds.bumpLRU(uri)
+		}
+		return text, true
+	}
+	ds.mu.RUnlock()
+
+	// Miss: read from disk *outside* the write lock so concurrent
+	// requests for other URIs aren't blocked behind file I/O. We only
+	// fall back to disk for file:// URIs - uri.Filename() panics on
+	// other schemes (e.g. untitled:), so guard before calling it.
+	if !strings.HasPrefix(uri, "file://") {
+		return "", false
+	}
+	path := uriToPath(protocol.DocumentURI(uri))
+	if path == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	text := string(data)
+
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	// Re-check: another goroutine may have populated this URI (via Set
+	// or a concurrent GetOrLoad) while we were reading from disk. If so,
+	// prefer the existing entry - Set wins by definition; a concurrent
+	// transient load is equivalent to ours.
+	if existing, ok := ds.docs[uri]; ok {
+		return existing.text, true
+	}
+
+	ds.docs[uri] = &cachedDoc{text: text, transient: true}
+	ds.transientIdx[uri] = ds.transientList.PushFront(uri)
+	ds.evictTransientLocked()
+	return text, true
+}
+
+// bumpLRU moves a transient URI to the front of the LRU list. Called on
+// every hit against a transient entry so the eviction order tracks
+// recency-of-use rather than recency-of-load.
+func (ds *DocumentStore) bumpLRU(uri string) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	if elem, ok := ds.transientIdx[uri]; ok {
+		ds.transientList.MoveToFront(elem)
+	}
+}
+
+// removeFromLRULocked removes a URI from LRU tracking. Caller must hold
+// the write lock. Safe to call for URIs that aren't tracked.
+func (ds *DocumentStore) removeFromLRULocked(uri string) {
+	if elem, ok := ds.transientIdx[uri]; ok {
+		ds.transientList.Remove(elem)
+		delete(ds.transientIdx, uri)
+	}
+}
+
+// evictTransientLocked drops the least-recently-used transient entry
+// while the transient population exceeds the cap. Caller must hold the
+// write lock.
+func (ds *DocumentStore) evictTransientLocked() {
+	for ds.transientList.Len() > ds.maxTransient {
+		elem := ds.transientList.Back()
+		if elem == nil {
+			return
+		}
+		victim := elem.Value.(string)
+		ds.transientList.Remove(elem)
+		delete(ds.transientIdx, victim)
+		if doc, ok := ds.docs[victim]; ok {
+			if doc.tree != nil {
+				doc.tree.Close()
+			}
+			delete(ds.docs, victim)
+		}
+	}
 }
 
 // GetTree returns a cached tree-sitter parse tree and its source bytes for

--- a/internal/lsp/documents.go
+++ b/internal/lsp/documents.go
@@ -162,14 +162,20 @@ func (ds *DocumentStore) Get(uri string) (string, bool) {
 	return doc.text, true
 }
 
-// HasOpen reports whether the given URI is an editor-owned (non-transient)
-// entry in the store - i.e. the editor sent a didOpen for this document.
-// Transient entries loaded from disk via GetOrLoad return false.
-func (ds *DocumentStore) HasOpen(uri string) bool {
+// GetIfOpen returns the text for the given URI, but only if the entry is
+// editor-owned (non-transient) — i.e. the editor sent a didOpen. Returns
+// ("", false) for transient entries loaded via GetOrLoad and for URIs
+// that are not in the store at all. This is an atomic single-lock check
+// distinct from calling HasOpen followed by Get, which would be a
+// TOCTOU race if Close interleaves between the two RLock acquisitions.
+func (ds *DocumentStore) GetIfOpen(uri string) (string, bool) {
 	ds.mu.RLock()
 	defer ds.mu.RUnlock()
 	doc, ok := ds.docs[uri]
-	return ok && !doc.transient
+	if !ok || doc.transient {
+		return "", false
+	}
+	return doc.text, true
 }
 
 // GetOrLoad returns the text for the given URI, falling back to a disk

--- a/internal/lsp/documents.go
+++ b/internal/lsp/documents.go
@@ -162,6 +162,16 @@ func (ds *DocumentStore) Get(uri string) (string, bool) {
 	return doc.text, true
 }
 
+// HasOpen reports whether the given URI is an editor-owned (non-transient)
+// entry in the store - i.e. the editor sent a didOpen for this document.
+// Transient entries loaded from disk via GetOrLoad return false.
+func (ds *DocumentStore) HasOpen(uri string) bool {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+	doc, ok := ds.docs[uri]
+	return ok && !doc.transient
+}
+
 // GetOrLoad returns the text for the given URI, falling back to a disk
 // read if no editor has opened the document. Disk-loaded entries are
 // marked transient and tracked in an LRU; if the transient population

--- a/internal/lsp/documents.go
+++ b/internal/lsp/documents.go
@@ -20,7 +20,7 @@ const defaultMaxTransient = 50
 
 type cachedDoc struct {
 	text       string
-	tree       *tree_sitter.Tree
+	tree       *refTree
 	src        []byte         // source bytes the tree references - must stay alive
 	tokens     []parser.Token // cached tokenizer output
 	tokSrc     []byte         // source bytes for tokens
@@ -30,6 +30,38 @@ type cachedDoc struct {
 	// LRU and evicted once the transient cap is reached. Editor-owned
 	// entries (created via Set) are never transient and never evicted.
 	transient bool
+}
+
+// refTree wraps a tree-sitter parse tree with refcounting so that
+// concurrent handlers walking the tree (RootNode, queries) aren't racing
+// with eviction or replacement, which would free the underlying C memory
+// via ts_tree_delete and cause a use-after-free that the Go race detector
+// cannot observe.
+//
+// Lifecycle: GetTree increments refs under the store write lock; the
+// returned release closure decrements under the same lock and frees the
+// tree only once refs==0 AND retired is set. Set/Close/CloseAll/eviction
+// don't close the tree directly - they call retireLocked, which marks the
+// tree for free and only triggers ts_tree_delete if no handler still
+// holds a reference.
+type refTree struct {
+	tree    *tree_sitter.Tree
+	refs    int
+	retired bool
+}
+
+// retireLocked marks the tree for free. Caller must hold the store write
+// lock. If no handler is currently using the tree, frees it immediately;
+// otherwise the last release closes it.
+func (rt *refTree) retireLocked() {
+	if rt == nil || rt.tree == nil {
+		return
+	}
+	rt.retired = true
+	if rt.refs == 0 {
+		rt.tree.Close()
+		rt.tree = nil
+	}
 }
 
 // DocumentStore tracks the text content of open buffers and caches
@@ -69,7 +101,7 @@ func NewDocumentStore() *DocumentStore {
 }
 
 // SetMaxTransient updates the cap on disk-loaded (transient) entries and
-// evicts any excess immediately. A cap of 0 disables transient caching —
+// evicts any excess immediately. A cap of 0 disables transient caching -
 // disk-loaded entries are inserted and immediately evicted, so the store
 // still serves the read but never retains it. Editor-owned entries are
 // never affected. Negative values are clamped to 0.
@@ -86,8 +118,8 @@ func (ds *DocumentStore) SetMaxTransient(n int) {
 func (ds *DocumentStore) Set(uri string, text string) {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
-	if doc, ok := ds.docs[uri]; ok && doc.tree != nil {
-		doc.tree.Close()
+	if doc, ok := ds.docs[uri]; ok {
+		doc.tree.retireLocked()
 	}
 	// Editor took ownership of this URI - drop any LRU tracking for it.
 	ds.removeFromLRULocked(uri)
@@ -97,21 +129,22 @@ func (ds *DocumentStore) Set(uri string, text string) {
 func (ds *DocumentStore) Close(uri string) {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
-	if doc, ok := ds.docs[uri]; ok && doc.tree != nil {
-		doc.tree.Close()
+	if doc, ok := ds.docs[uri]; ok {
+		doc.tree.retireLocked()
 	}
 	ds.removeFromLRULocked(uri)
 	delete(ds.docs, uri)
 }
 
-// CloseAll frees all cached trees and the shared parser.
+// CloseAll frees all cached trees and the shared parser. Trees still
+// referenced by in-flight handlers stay alive until released; the parser
+// itself is safe to close immediately because parse trees are independent
+// of the parser once produced.
 func (ds *DocumentStore) CloseAll() {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 	for _, doc := range ds.docs {
-		if doc.tree != nil {
-			doc.tree.Close()
-		}
+		doc.tree.retireLocked()
 	}
 	ds.docs = nil
 	ds.transientList = nil
@@ -222,29 +255,50 @@ func (ds *DocumentStore) evictTransientLocked() {
 		ds.transientList.Remove(elem)
 		delete(ds.transientIdx, victim)
 		if doc, ok := ds.docs[victim]; ok {
-			if doc.tree != nil {
-				doc.tree.Close()
-			}
+			doc.tree.retireLocked()
 			delete(ds.docs, victim)
 		}
 	}
 }
 
 // GetTree returns a cached tree-sitter parse tree and its source bytes for
-// the given URI. Parses on first access and caches the result. The tree is
-// invalidated on the next Set() call. Callers must not close the returned tree.
-func (ds *DocumentStore) GetTree(uri string) (*tree_sitter.Tree, []byte, bool) {
+// the given URI. Parses on first access and caches the result.
+//
+// The returned release closure MUST be called exactly once when the caller
+// is done with the tree (typically via defer). It increments the tree's
+// refcount under the store lock for the duration of the caller's use,
+// keeping the underlying C memory alive even if Set/Close/CloseAll or LRU
+// eviction concurrently retires the tree. Without this, a concurrent
+// GetOrLoad for one URI could evict and free the tree of another URI
+// while a handler is still walking it - a use-after-free on C memory that
+// the Go race detector cannot catch.
+//
+// Callers must not close the returned tree directly.
+//
+// When ok is false, release is nil and must not be called.
+func (ds *DocumentStore) GetTree(uri string) (*tree_sitter.Tree, []byte, func(), bool) {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 	doc, ok := ds.docs[uri]
 	if !ok {
-		return nil, nil, false
+		return nil, nil, nil, false
 	}
 	if doc.tree == nil {
 		doc.src = []byte(doc.text)
-		doc.tree = ds.parser.Parse(doc.src, nil)
+		doc.tree = &refTree{tree: ds.parser.Parse(doc.src, nil)}
 	}
-	return doc.tree, doc.src, true
+	rt := doc.tree
+	rt.refs++
+	release := func() {
+		ds.mu.Lock()
+		defer ds.mu.Unlock()
+		rt.refs--
+		if rt.refs == 0 && rt.retired && rt.tree != nil {
+			rt.tree.Close()
+			rt.tree = nil
+		}
+	}
+	return rt.tree, doc.src, release, true
 }
 
 // GetTokens returns cached tokenizer output and source bytes for the given URI.

--- a/internal/lsp/documents_test.go
+++ b/internal/lsp/documents_test.go
@@ -379,10 +379,10 @@ func TestDocumentStore_SetMaxTransient_EvictsImmediately(t *testing.T) {
 	}
 }
 
-func TestDocumentStore_HasOpen(t *testing.T) {
+func TestDocumentStore_GetIfOpen(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "hasopen.ex")
-	if err := os.WriteFile(path, []byte("defmodule HasOpen do\nend\n"), 0644); err != nil {
+	path := filepath.Join(dir, "getifopen.ex")
+	if err := os.WriteFile(path, []byte("defmodule GetIfOpen do\nend\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -391,36 +391,39 @@ func TestDocumentStore_HasOpen(t *testing.T) {
 	docURI := string(uri.File(path))
 
 	// Nothing in the store yet.
-	if ds.HasOpen(docURI) {
-		t.Fatalf("HasOpen returned true for a URI that was never opened or loaded")
+	if _, ok := ds.GetIfOpen(docURI); ok {
+		t.Fatalf("GetIfOpen returned true for a URI that was never opened or loaded")
 	}
 
 	// GetOrLoad adds a transient entry - NOT editor-owned.
 	if _, ok := ds.GetOrLoad(docURI); !ok {
 		t.Fatalf("GetOrLoad failed")
 	}
-	if ds.HasOpen(docURI) {
-		t.Fatalf("HasOpen returned true for a transient (disk-loaded) entry")
+	if _, ok := ds.GetIfOpen(docURI); ok {
+		t.Fatalf("GetIfOpen returned true for a transient (disk-loaded) entry")
 	}
 
 	// Set adds an editor-owned entry - IS open.
-	ds.Set(docURI, "defmodule HasOpen do\n  def open, do: true\nend\n")
-	if !ds.HasOpen(docURI) {
-		t.Fatalf("HasOpen returned false for an editor-owned entry after Set")
+	editorText := "defmodule GetIfOpen do\n  def open, do: true\nend\n"
+	ds.Set(docURI, editorText)
+	if text, ok := ds.GetIfOpen(docURI); !ok {
+		t.Fatalf("GetIfOpen returned false for an editor-owned entry after Set")
+	} else if text != editorText {
+		t.Fatalf("GetIfOpen returned wrong text: got %q want %q", text, editorText)
 	}
 
 	// Close removes the entry.
 	ds.Close(docURI)
-	if ds.HasOpen(docURI) {
-		t.Fatalf("HasOpen returned true after Close")
+	if _, ok := ds.GetIfOpen(docURI); ok {
+		t.Fatalf("GetIfOpen returned true after Close")
 	}
 
 	// GetOrLoad re-adds it as transient - NOT open.
 	if _, ok := ds.GetOrLoad(docURI); !ok {
 		t.Fatalf("GetOrLoad after Close failed")
 	}
-	if ds.HasOpen(docURI) {
-		t.Fatalf("HasOpen returned true for transient entry after re-load")
+	if _, ok := ds.GetIfOpen(docURI); ok {
+		t.Fatalf("GetIfOpen returned true for transient entry after re-load")
 	}
 }
 

--- a/internal/lsp/documents_test.go
+++ b/internal/lsp/documents_test.go
@@ -1,0 +1,381 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"go.lsp.dev/uri"
+)
+
+func TestDocumentStore_GetOrLoad_DiskFallback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "example.ex")
+	contents := "defmodule Example do\n  def hello, do: :world\nend\n"
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+
+	docURI := string(uri.File(path))
+
+	// Buffer was never opened - Get should miss.
+	if _, ok := ds.Get(docURI); ok {
+		t.Fatalf("Get returned true for a URI that was never opened")
+	}
+
+	// GetOrLoad should populate the store from disk.
+	text, ok := ds.GetOrLoad(docURI)
+	if !ok {
+		t.Fatalf("GetOrLoad returned false for an existing file")
+	}
+	if text != contents {
+		t.Fatalf("GetOrLoad returned wrong text: got %q want %q", text, contents)
+	}
+
+	// After loading, Get should also hit.
+	if got, ok := ds.Get(docURI); !ok || got != contents {
+		t.Fatalf("Get after GetOrLoad: ok=%v text=%q", ok, got)
+	}
+
+	// And the entry should be marked transient.
+	ds.mu.RLock()
+	doc := ds.docs[docURI]
+	ds.mu.RUnlock()
+	if doc == nil || !doc.transient {
+		t.Fatalf("expected disk-loaded entry to be transient, got %+v", doc)
+	}
+}
+
+func TestDocumentStore_GetOrLoad_MissingFile(t *testing.T) {
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+
+	docURI := string(uri.File("/nonexistent/path/does/not/exist.ex"))
+	if _, ok := ds.GetOrLoad(docURI); ok {
+		t.Fatalf("GetOrLoad returned true for a nonexistent file")
+	}
+	// And nothing should have been inserted into the store.
+	if _, ok := ds.Get(docURI); ok {
+		t.Fatalf("missing file should not have been cached")
+	}
+}
+
+func TestDocumentStore_GetOrLoad_NonFileURI(t *testing.T) {
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+
+	// untitled:// and other non-file schemes shouldn't trigger a disk read.
+	if _, ok := ds.GetOrLoad("untitled:Untitled-1"); ok {
+		t.Fatalf("GetOrLoad returned true for non-file URI")
+	}
+}
+
+func TestDocumentStore_GetOrLoad_LRUEviction(t *testing.T) {
+	dir := t.TempDir()
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+	ds.maxTransient = 3
+
+	uris := make([]string, 0, 5)
+	for i := 0; i < 5; i++ {
+		path := filepath.Join(dir, "file"+strconv.Itoa(i)+".ex")
+		if err := os.WriteFile(path, []byte("defmodule F"+strconv.Itoa(i)+" do\nend\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		uris = append(uris, string(uri.File(path)))
+	}
+
+	// Load 3 files - fills the cap exactly.
+	for i := 0; i < 3; i++ {
+		if _, ok := ds.GetOrLoad(uris[i]); !ok {
+			t.Fatalf("GetOrLoad(%d) failed", i)
+		}
+	}
+	if got := transientCount(ds); got != 3 {
+		t.Fatalf("expected 3 transient entries, got %d", got)
+	}
+
+	// Touch file 0 so it becomes most-recently-used.
+	if _, ok := ds.GetOrLoad(uris[0]); !ok {
+		t.Fatalf("hit on uris[0] failed")
+	}
+
+	// Load files 3 and 4. They should evict files 1 and 2 (LRU), not 0.
+	for _, i := range []int{3, 4} {
+		if _, ok := ds.GetOrLoad(uris[i]); !ok {
+			t.Fatalf("GetOrLoad(%d) failed", i)
+		}
+	}
+
+	if got := transientCount(ds); got != 3 {
+		t.Fatalf("expected 3 transient entries after eviction, got %d", got)
+	}
+
+	// file 0 should still be present (we bumped it).
+	if _, ok := ds.Get(uris[0]); !ok {
+		t.Fatalf("uris[0] was incorrectly evicted")
+	}
+	// files 1 and 2 should be evicted.
+	for _, i := range []int{1, 2} {
+		if _, ok := ds.Get(uris[i]); ok {
+			t.Fatalf("uris[%d] should have been evicted", i)
+		}
+	}
+	// files 3 and 4 are the newest, should remain.
+	for _, i := range []int{3, 4} {
+		if _, ok := ds.Get(uris[i]); !ok {
+			t.Fatalf("uris[%d] should still be present", i)
+		}
+	}
+}
+
+func TestDocumentStore_Set_PromotesTransientToEditorOwned(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "promote.ex")
+	if err := os.WriteFile(path, []byte("defmodule Promote do\nend\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+	docURI := string(uri.File(path))
+
+	// Load via disk fallback first.
+	if _, ok := ds.GetOrLoad(docURI); !ok {
+		t.Fatalf("GetOrLoad failed")
+	}
+	if transientCount(ds) != 1 {
+		t.Fatalf("expected 1 transient entry, got %d", transientCount(ds))
+	}
+
+	// Now simulate an editor didOpen with newer content.
+	editorText := "defmodule Promote do\n  def edited, do: :ok\nend\n"
+	ds.Set(docURI, editorText)
+
+	// The transient bookkeeping should be gone.
+	if transientCount(ds) != 0 {
+		t.Fatalf("expected 0 transient entries after Set, got %d", transientCount(ds))
+	}
+
+	// And the entry should no longer be flagged transient.
+	ds.mu.RLock()
+	doc := ds.docs[docURI]
+	ds.mu.RUnlock()
+	if doc == nil {
+		t.Fatalf("entry missing after Set")
+	}
+	if doc.transient {
+		t.Fatalf("entry should be editor-owned after Set, still marked transient")
+	}
+	if doc.text != editorText {
+		t.Fatalf("Set did not overwrite text: got %q want %q", doc.text, editorText)
+	}
+}
+
+func TestDocumentStore_Close_RemovesFromLRU(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "close.ex")
+	if err := os.WriteFile(path, []byte("defmodule Close do\nend\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+	docURI := string(uri.File(path))
+
+	if _, ok := ds.GetOrLoad(docURI); !ok {
+		t.Fatalf("GetOrLoad failed")
+	}
+	if transientCount(ds) != 1 {
+		t.Fatalf("expected 1 transient entry, got %d", transientCount(ds))
+	}
+
+	ds.Close(docURI)
+
+	if transientCount(ds) != 0 {
+		t.Fatalf("expected 0 transient entries after Close, got %d", transientCount(ds))
+	}
+	if _, ok := ds.Get(docURI); ok {
+		t.Fatalf("entry should be gone after Close")
+	}
+}
+
+func TestDocumentStore_GetOrLoad_EditorOwnedNotEvicted(t *testing.T) {
+	dir := t.TempDir()
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+	ds.maxTransient = 2
+
+	// Editor opens a buffer for "editor.ex".
+	editorPath := filepath.Join(dir, "editor.ex")
+	if err := os.WriteFile(editorPath, []byte("ignored\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	editorURI := string(uri.File(editorPath))
+	ds.Set(editorURI, "defmodule Editor do\nend\n")
+
+	// Now load 5 transient files - well over the cap of 2.
+	for i := 0; i < 5; i++ {
+		path := filepath.Join(dir, "t"+strconv.Itoa(i)+".ex")
+		if err := os.WriteFile(path, []byte("defmodule T do\nend\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := ds.GetOrLoad(string(uri.File(path))); !ok {
+			t.Fatalf("GetOrLoad t%d failed", i)
+		}
+	}
+
+	// Editor-owned entry must still be present.
+	if _, ok := ds.Get(editorURI); !ok {
+		t.Fatalf("editor-owned entry was evicted")
+	}
+	if transientCount(ds) != 2 {
+		t.Fatalf("expected 2 transient entries, got %d", transientCount(ds))
+	}
+}
+
+func TestDocumentStore_GetTree_DiskLoaded(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tree.ex")
+	contents := "defmodule Tree do\n  def hello, do: :world\nend\n"
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+	docURI := string(uri.File(path))
+
+	if _, ok := ds.GetOrLoad(docURI); !ok {
+		t.Fatalf("GetOrLoad failed")
+	}
+
+	tree, src, ok := ds.GetTree(docURI)
+	if !ok {
+		t.Fatalf("GetTree returned ok=false for disk-loaded entry")
+	}
+	if tree == nil {
+		t.Fatalf("GetTree returned nil tree")
+	}
+	if string(src) != contents {
+		t.Fatalf("GetTree src mismatch: got %q want %q", src, contents)
+	}
+	if tree.RootNode().Kind() != "source" {
+		t.Fatalf("expected root node kind 'source', got %q", tree.RootNode().Kind())
+	}
+}
+
+func TestDocumentStore_GetTokens_DiskLoaded(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tokens.ex")
+	contents := "defmodule Tokens do\nend\n"
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+	docURI := string(uri.File(path))
+
+	if _, ok := ds.GetOrLoad(docURI); !ok {
+		t.Fatalf("GetOrLoad failed")
+	}
+
+	tokens, src, lineStarts, ok := ds.GetTokensFull(docURI)
+	if !ok {
+		t.Fatalf("GetTokensFull returned ok=false for disk-loaded entry")
+	}
+	if len(tokens) == 0 {
+		t.Fatalf("expected non-empty token stream")
+	}
+	if string(src) != contents {
+		t.Fatalf("GetTokensFull src mismatch: got %q want %q", src, contents)
+	}
+	// "defmodule\n...\nend\n" has 3 newlines, so 4 line starts (incl. line 0).
+	if len(lineStarts) < 3 {
+		t.Fatalf("expected at least 3 line starts, got %d", len(lineStarts))
+	}
+}
+
+func TestDocumentStore_GetTree_SetInvalidatesCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "invalidate.ex")
+	if err := os.WriteFile(path, []byte("defmodule A do\nend\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+	docURI := string(uri.File(path))
+
+	if _, ok := ds.GetOrLoad(docURI); !ok {
+		t.Fatalf("GetOrLoad failed")
+	}
+	tree1, src1, _ := ds.GetTree(docURI)
+	if tree1 == nil {
+		t.Fatalf("first GetTree returned nil")
+	}
+
+	// Editor opens the buffer with different content — Set must replace the
+	// cached tree, otherwise stale parses would leak across the transition
+	// from transient to editor-owned.
+	editorText := "defmodule B do\n  def x, do: 1\nend\n"
+	ds.Set(docURI, editorText)
+
+	tree2, src2, ok := ds.GetTree(docURI)
+	if !ok {
+		t.Fatalf("GetTree after Set returned ok=false")
+	}
+	if tree2 == nil {
+		t.Fatalf("GetTree after Set returned nil tree")
+	}
+	if string(src2) == string(src1) {
+		t.Fatalf("expected fresh source after Set, got the original")
+	}
+	if string(src2) != editorText {
+		t.Fatalf("GetTree src mismatch after Set: got %q want %q", src2, editorText)
+	}
+}
+
+func TestDocumentStore_SetMaxTransient_EvictsImmediately(t *testing.T) {
+	dir := t.TempDir()
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+
+	for i := 0; i < 4; i++ {
+		path := filepath.Join(dir, "f"+strconv.Itoa(i)+".ex")
+		if err := os.WriteFile(path, []byte("defmodule F do\nend\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := ds.GetOrLoad(string(uri.File(path))); !ok {
+			t.Fatalf("GetOrLoad(%d) failed", i)
+		}
+	}
+	if transientCount(ds) != 4 {
+		t.Fatalf("expected 4 transient entries, got %d", transientCount(ds))
+	}
+
+	// Lowering the cap should evict the oldest entries immediately.
+	ds.SetMaxTransient(2)
+	if got := transientCount(ds); got != 2 {
+		t.Fatalf("expected 2 transient entries after SetMaxTransient(2), got %d", got)
+	}
+
+	// Negative values clamp to 0 and drain everything.
+	ds.SetMaxTransient(-1)
+	if got := transientCount(ds); got != 0 {
+		t.Fatalf("expected 0 transient entries after SetMaxTransient(-1), got %d", got)
+	}
+}
+
+// transientCount returns the number of transient entries currently
+// tracked by the LRU. Used by tests; takes the read lock.
+func transientCount(ds *DocumentStore) int {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+	return ds.transientList.Len()
+}

--- a/internal/lsp/documents_test.go
+++ b/internal/lsp/documents_test.go
@@ -379,6 +379,51 @@ func TestDocumentStore_SetMaxTransient_EvictsImmediately(t *testing.T) {
 	}
 }
 
+func TestDocumentStore_HasOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hasopen.ex")
+	if err := os.WriteFile(path, []byte("defmodule HasOpen do\nend\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+	docURI := string(uri.File(path))
+
+	// Nothing in the store yet.
+	if ds.HasOpen(docURI) {
+		t.Fatalf("HasOpen returned true for a URI that was never opened or loaded")
+	}
+
+	// GetOrLoad adds a transient entry - NOT editor-owned.
+	if _, ok := ds.GetOrLoad(docURI); !ok {
+		t.Fatalf("GetOrLoad failed")
+	}
+	if ds.HasOpen(docURI) {
+		t.Fatalf("HasOpen returned true for a transient (disk-loaded) entry")
+	}
+
+	// Set adds an editor-owned entry - IS open.
+	ds.Set(docURI, "defmodule HasOpen do\n  def open, do: true\nend\n")
+	if !ds.HasOpen(docURI) {
+		t.Fatalf("HasOpen returned false for an editor-owned entry after Set")
+	}
+
+	// Close removes the entry.
+	ds.Close(docURI)
+	if ds.HasOpen(docURI) {
+		t.Fatalf("HasOpen returned true after Close")
+	}
+
+	// GetOrLoad re-adds it as transient - NOT open.
+	if _, ok := ds.GetOrLoad(docURI); !ok {
+		t.Fatalf("GetOrLoad after Close failed")
+	}
+	if ds.HasOpen(docURI) {
+		t.Fatalf("HasOpen returned true for transient entry after re-load")
+	}
+}
+
 // transientCount returns the number of transient entries currently
 // tracked by the LRU. Used by tests; takes the read lock.
 func transientCount(ds *DocumentStore) int {

--- a/internal/lsp/documents_test.go
+++ b/internal/lsp/documents_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"testing"
 
 	"go.lsp.dev/uri"
@@ -254,10 +255,11 @@ func TestDocumentStore_GetTree_DiskLoaded(t *testing.T) {
 		t.Fatalf("GetOrLoad failed")
 	}
 
-	tree, src, ok := ds.GetTree(docURI)
+	tree, src, release, ok := ds.GetTree(docURI)
 	if !ok {
 		t.Fatalf("GetTree returned ok=false for disk-loaded entry")
 	}
+	defer release()
 	if tree == nil {
 		t.Fatalf("GetTree returned nil tree")
 	}
@@ -315,21 +317,26 @@ func TestDocumentStore_GetTree_SetInvalidatesCache(t *testing.T) {
 	if _, ok := ds.GetOrLoad(docURI); !ok {
 		t.Fatalf("GetOrLoad failed")
 	}
-	tree1, src1, _ := ds.GetTree(docURI)
+	tree1, src1, release1, _ := ds.GetTree(docURI)
 	if tree1 == nil {
 		t.Fatalf("first GetTree returned nil")
 	}
+	// Release before Set so the old tree is freed inline (refcount→0) rather
+	// than retired-and-deferred; the Set-replaces-tree invariant is the
+	// behavior under test, not the deferred-free path.
+	release1()
 
-	// Editor opens the buffer with different content — Set must replace the
+	// Editor opens the buffer with different content - Set must replace the
 	// cached tree, otherwise stale parses would leak across the transition
 	// from transient to editor-owned.
 	editorText := "defmodule B do\n  def x, do: 1\nend\n"
 	ds.Set(docURI, editorText)
 
-	tree2, src2, ok := ds.GetTree(docURI)
+	tree2, src2, release2, ok := ds.GetTree(docURI)
 	if !ok {
 		t.Fatalf("GetTree after Set returned ok=false")
 	}
+	defer release2()
 	if tree2 == nil {
 		t.Fatalf("GetTree after Set returned nil tree")
 	}
@@ -378,4 +385,113 @@ func transientCount(ds *DocumentStore) int {
 	ds.mu.RLock()
 	defer ds.mu.RUnlock()
 	return ds.transientList.Len()
+}
+
+// TestDocumentStore_GetTree_SurvivesEviction is the regression test for
+// the use-after-free where cross-URI LRU eviction calls ts_tree_delete on
+// a tree another handler is actively walking. With refcounted release,
+// the underlying tree must stay alive past eviction until the holder
+// calls release().
+func TestDocumentStore_GetTree_SurvivesEviction(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "victim.ex")
+	contents := "defmodule Victim do\n  def hello, do: :world\nend\n"
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+	docURI := string(uri.File(path))
+
+	if _, ok := ds.GetOrLoad(docURI); !ok {
+		t.Fatalf("GetOrLoad failed")
+	}
+
+	tree, _, release, ok := ds.GetTree(docURI)
+	if !ok {
+		t.Fatalf("GetTree returned ok=false")
+	}
+	if tree == nil {
+		t.Fatalf("GetTree returned nil tree")
+	}
+
+	// Capture the root node kind so we can re-read it after eviction.
+	// Pre-fix, the eviction below would call ts_tree_delete on this tree
+	// and the second RootNode() call would read freed C memory.
+	rootKindBefore := tree.RootNode().Kind()
+
+	// Force eviction of this URI while we still hold a ref.
+	ds.SetMaxTransient(0)
+	if got := transientCount(ds); got != 0 {
+		t.Fatalf("expected 0 transient entries after SetMaxTransient(0), got %d", got)
+	}
+
+	// Walking the tree after eviction must still work - this is the UAF
+	// the refcounting prevents.
+	rootKindAfter := tree.RootNode().Kind()
+	if rootKindAfter != rootKindBefore {
+		t.Fatalf("tree root kind changed across eviction: got %q want %q", rootKindAfter, rootKindBefore)
+	}
+	if rootKindAfter != "source" {
+		t.Fatalf("expected root node kind 'source', got %q", rootKindAfter)
+	}
+
+	// Release should now actually free the underlying C tree (refcount→0
+	// and retired is set). Nothing to assert directly - the absence of a
+	// crash on CloseAll later is the implicit check.
+	release()
+}
+
+// TestDocumentStore_GetTree_ConcurrentEvictionStress runs many goroutines
+// that load + walk + release trees against a small transient cap, which
+// keeps eviction happening continuously. Designed to catch the UAF race
+// when run under -race; pre-fix this reliably crashed on
+// ts_tree_delete'd memory.
+func TestDocumentStore_GetTree_ConcurrentEvictionStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stress test in -short mode")
+	}
+	dir := t.TempDir()
+
+	const numURIs = 8
+	uris := make([]string, numURIs)
+	for i := 0; i < numURIs; i++ {
+		path := filepath.Join(dir, "f"+strconv.Itoa(i)+".ex")
+		body := "defmodule F" + strconv.Itoa(i) + " do\n  def hello, do: :world\nend\n"
+		if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+		uris[i] = string(uri.File(path))
+	}
+
+	ds := NewDocumentStore()
+	defer ds.CloseAll()
+	// Cap well below the working set so every load triggers eviction.
+	ds.SetMaxTransient(2)
+
+	const iterations = 200
+	const walkers = 4
+	var wg sync.WaitGroup
+	for w := 0; w < walkers; w++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				u := uris[(seed+i)%numURIs]
+				if _, ok := ds.GetOrLoad(u); !ok {
+					continue
+				}
+				tree, _, release, ok := ds.GetTree(u)
+				if !ok {
+					continue
+				}
+				root := tree.RootNode()
+				_ = root.Kind()
+				_ = root.ChildCount()
+				release()
+			}
+		}(w)
+	}
+	wg.Wait()
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -324,6 +324,14 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 		if v, ok := opts["debug"].(bool); ok {
 			s.debug = v
 		}
+		// JSON numbers decode to float64. Accept either form so a client
+		// sending an integer literal still works.
+		switch v := opts["maxTransientDocuments"].(type) {
+		case float64:
+			s.docs.SetMaxTransient(int(v))
+		case int:
+			s.docs.SetMaxTransient(v)
+		}
 	}
 	if os.Getenv("DEXTER_DEBUG") == "true" {
 		s.debug = true
@@ -565,7 +573,7 @@ func (s *Server) Definition(ctx context.Context, params *protocol.DefinitionPara
 		defer func() { s.debugf("Definition: total %s", time.Since(t0).Round(time.Microsecond)) }()
 	}
 
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -1230,7 +1238,7 @@ func (s *Server) LogTrace(ctx context.Context, params *protocol.LogTraceParams) 
 func (s *Server) SetTrace(ctx context.Context, params *protocol.SetTraceParams) error { return nil }
 func (s *Server) CodeAction(ctx context.Context, params *protocol.CodeActionParams) ([]protocol.CodeAction, error) {
 	docURI := string(params.TextDocument.URI)
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -1402,7 +1410,7 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 	docURI := string(params.TextDocument.URI)
 	filePath := uriToPath(params.TextDocument.URI)
 
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -2418,7 +2426,7 @@ func (s *Server) Declaration(ctx context.Context, params *protocol.DeclarationPa
 		defer func() { s.debugf("Declaration: total %s", time.Since(t0).Round(time.Microsecond)) }()
 	}
 
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		s.debugf("Declaration: document not open")
 		return nil, nil
@@ -2642,7 +2650,7 @@ func (s *Server) DocumentColor(ctx context.Context, params *protocol.DocumentCol
 }
 func (s *Server) DocumentHighlight(ctx context.Context, params *protocol.DocumentHighlightParams) ([]protocol.DocumentHighlight, error) {
 	docURI := string(params.TextDocument.URI)
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -2714,7 +2722,7 @@ func (s *Server) DocumentLinkResolve(ctx context.Context, params *protocol.Docum
 }
 func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSymbolParams) ([]interface{}, error) {
 	docURI := string(params.TextDocument.URI)
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -3220,7 +3228,7 @@ func (s *Server) ExecuteCommand(ctx context.Context, params *protocol.ExecuteCom
 }
 func (s *Server) FoldingRanges(ctx context.Context, params *protocol.FoldingRangeParams) ([]protocol.FoldingRange, error) {
 	docURI := string(params.TextDocument.URI)
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -3364,7 +3372,7 @@ func (s *Server) Formatting(ctx context.Context, params *protocol.DocumentFormat
 func (s *Server) Hover(ctx context.Context, params *protocol.HoverParams) (*protocol.Hover, error) {
 	docURI := string(params.TextDocument.URI)
 
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -3479,7 +3487,7 @@ func (s *Server) Implementation(ctx context.Context, params *protocol.Implementa
 		defer func() { s.debugf("Implementation: total %s", time.Since(t0).Round(time.Microsecond)) }()
 	}
 
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -3546,7 +3554,7 @@ func (s *Server) OnTypeFormatting(ctx context.Context, params *protocol.Document
 }
 func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRenameParams) (*protocol.Range, error) {
 	docURI := string(params.TextDocument.URI)
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -3689,7 +3697,7 @@ func (s *Server) References(ctx context.Context, params *protocol.ReferenceParam
 		defer func() { s.debugf("References: total %s", time.Since(t).Round(time.Microsecond)) }()
 	}
 
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		s.debugf("References: document not found in store")
 		return nil, nil
@@ -3949,7 +3957,7 @@ func (s *Server) References(ctx context.Context, params *protocol.ReferenceParam
 
 func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*protocol.WorkspaceEdit, error) {
 	docURI := string(params.TextDocument.URI)
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -5010,7 +5018,7 @@ func (s *Server) findBareCallRefs(module, functionName string) []store.Reference
 }
 func (s *Server) SignatureHelp(ctx context.Context, params *protocol.SignatureHelpParams) (*protocol.SignatureHelp, error) {
 	docURI := string(params.TextDocument.URI)
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -5177,7 +5185,7 @@ func (s *Server) Symbols(ctx context.Context, params *protocol.WorkspaceSymbolPa
 }
 func (s *Server) TypeDefinition(ctx context.Context, params *protocol.TypeDefinitionParams) ([]protocol.Location, error) {
 	docURI := string(params.TextDocument.URI)
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}
@@ -5250,7 +5258,7 @@ func (s *Server) DidDeleteFiles(ctx context.Context, params *protocol.DeleteFile
 func (s *Server) CodeLensRefresh(ctx context.Context) error { return nil }
 func (s *Server) PrepareCallHierarchy(ctx context.Context, params *protocol.CallHierarchyPrepareParams) ([]protocol.CallHierarchyItem, error) {
 	docURI := string(params.TextDocument.URI)
-	text, ok := s.docs.Get(docURI)
+	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
 		return nil, nil
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -637,7 +637,8 @@ func (s *Server) Definition(ctx context.Context, params *protocol.DefinitionPara
 
 		// Variable go-to-definition via tree-sitter.
 		// The first occurrence in scope is the definition (pattern/assignment).
-		if tree, src, ok := s.docs.GetTree(docURI); ok {
+		if tree, src, release, ok := s.docs.GetTree(docURI); ok {
+			defer release()
 			if occs := treesitter.FindVariableOccurrencesWithTree(tree.RootNode(), src, uint(lineNum), uint(col)); len(occs) > 0 {
 				s.debugf("Definition: returning variable definition at line %d", occs[0].Line)
 				return []protocol.Location{{
@@ -1706,8 +1707,9 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 
 		// Variables in scope via tree-sitter
 		var varsInScope []string
-		if tree, src, ok := s.docs.GetTree(docURI); ok {
+		if tree, src, release, ok := s.docs.GetTree(docURI); ok {
 			varsInScope = treesitter.FindVariablesInScopeWithTree(tree.RootNode(), src, uint(lineNum), uint(col))
+			release()
 		}
 		for _, varName := range varsInScope {
 			if strings.HasPrefix(varName, funcPrefix) && !seen[varName] {
@@ -2658,10 +2660,11 @@ func (s *Server) DocumentHighlight(ctx context.Context, params *protocol.Documen
 	lineNum := int(params.Position.Line)
 	col := int(params.Position.Character)
 
-	tree, src, hasTree := s.docs.GetTree(docURI)
+	tree, src, release, hasTree := s.docs.GetTree(docURI)
 	if !hasTree {
 		return nil, nil
 	}
+	defer release()
 	root := tree.RootNode()
 
 	// Try scope-aware variable highlight first
@@ -3577,7 +3580,8 @@ func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRena
 	// For bare identifiers (no module qualifier), check tree-sitter variables
 	// first — a local variable shadows a same-named function in Elixir.
 	if moduleRef == "" {
-		if tree, src, ok := s.docs.GetTree(docURI); ok {
+		if tree, src, release, ok := s.docs.GetTree(docURI); ok {
+			defer release()
 			if occs := treesitter.FindVariableOccurrencesWithTree(tree.RootNode(), src, uint(lineNum), uint(col)); len(occs) > 0 {
 				for _, occ := range occs {
 					if occ.Line == uint(lineNum) && uint(col) >= occ.StartCol && uint(col) < occ.EndCol {
@@ -3774,7 +3778,8 @@ func (s *Server) References(ctx context.Context, params *protocol.ReferenceParam
 		// function with the same name, so variable references take priority.
 		// Bare identifiers that aren't defined as variables fall through to
 		// function reference lookup.
-		if tree, src, ok := s.docs.GetTree(docURI); ok {
+		if tree, src, release, ok := s.docs.GetTree(docURI); ok {
+			defer release()
 			if occs := treesitter.FindVariableOccurrencesWithTree(tree.RootNode(), src, uint(lineNum), uint(col)); len(occs) > 0 {
 				var locations []protocol.Location
 				for _, occ := range occs {
@@ -3979,7 +3984,8 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 	// For bare identifiers, check tree-sitter variables first — a local
 	// variable shadows a same-named function in Elixir.
 	if moduleRef == "" {
-		if tree, src, ok := s.docs.GetTree(docURI); ok {
+		if tree, src, release, ok := s.docs.GetTree(docURI); ok {
+			defer release()
 			if occs := treesitter.FindVariableOccurrencesWithTree(tree.RootNode(), src, uint(lineNum), uint(col)); len(occs) > 0 {
 				if treesitter.NameExistsInScopeOf(tree.RootNode(), src, uint(lineNum), uint(col), params.NewName) {
 					return nil, fmt.Errorf("variable %q already exists in this scope", params.NewName)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -4954,10 +4954,13 @@ func isDepsFileUncached(filePath string) bool {
 }
 
 // readFileText returns the contents of filePath, preferring the in-memory
-// document store for open buffers. The second return indicates whether the
-// file is currently open in the editor.
+// document store for editor-owned (didOpen) buffers. The second return
+// indicates whether the file is currently open in the editor — transient
+// entries loaded from disk via GetOrLoad are NOT reported as open.
 func (s *Server) readFileText(filePath string) (text string, open bool, ok bool) {
-	if t, found := s.docs.Get(string(uri.File(filePath))); found {
+	uri := string(uri.File(filePath))
+	if s.docs.HasOpen(uri) {
+		t, _ := s.docs.Get(uri)
 		return t, true, true
 	}
 	if data, err := os.ReadFile(filePath); err == nil {
@@ -4967,11 +4970,15 @@ func (s *Server) readFileText(filePath string) (text string, open bool, ok bool)
 }
 
 // getFileLine returns the text of line lineNum (1-based) from the file at
-// filePath, preferring the in-memory document store for open buffers.
-// For closed files, only reads up to the target line instead of the whole file.
+// filePath, preferring the in-memory document store for editor-owned
+// buffers. Transient entries loaded via GetOrLoad fall through to the
+// disk path. For closed files, only reads up to the target line instead
+// of the whole file.
 func (s *Server) getFileLine(filePath string, lineNum int) (string, bool) {
-	// Open buffer: extract the single line without splitting the entire text
-	if text, ok := s.docs.Get(string(uri.File(filePath))); ok {
+	// Editor-owned buffer: extract the single line from memory
+	uri := string(uri.File(filePath))
+	if s.docs.HasOpen(uri) {
+		text, _ := s.docs.Get(uri)
 		line, found := nthLine(text, lineNum-1)
 		if found {
 			return line, true

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -4954,8 +4954,7 @@ func isDepsFileUncached(filePath string) bool {
 // entries loaded from disk via GetOrLoad are NOT reported as open.
 func (s *Server) readFileText(filePath string) (text string, open bool, ok bool) {
 	uri := string(uri.File(filePath))
-	if s.docs.HasOpen(uri) {
-		t, _ := s.docs.Get(uri)
+	if t, found := s.docs.GetIfOpen(uri); found {
 		return t, true, true
 	}
 	if data, err := os.ReadFile(filePath); err == nil {
@@ -4972,8 +4971,7 @@ func (s *Server) readFileText(filePath string) (text string, open bool, ok bool)
 func (s *Server) getFileLine(filePath string, lineNum int) (string, bool) {
 	// Editor-owned buffer: extract the single line from memory
 	uri := string(uri.File(filePath))
-	if s.docs.HasOpen(uri) {
-		text, _ := s.docs.Get(uri)
+	if text, ok := s.docs.GetIfOpen(uri); ok {
 		line, found := nthLine(text, lineNum-1)
 		if found {
 			return line, true

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -324,13 +324,8 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 		if v, ok := opts["debug"].(bool); ok {
 			s.debug = v
 		}
-		// JSON numbers decode to float64. Accept either form so a client
-		// sending an integer literal still works.
-		switch v := opts["maxTransientDocuments"].(type) {
-		case float64:
+		if v, ok := opts["maxTransientDocuments"].(float64); ok {
 			s.docs.SetMaxTransient(int(v))
-		case int:
-			s.docs.SetMaxTransient(v)
 		}
 	}
 	if os.Getenv("DEXTER_DEBUG") == "true" {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1708,8 +1708,8 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 		// Variables in scope via tree-sitter
 		var varsInScope []string
 		if tree, src, release, ok := s.docs.GetTree(docURI); ok {
+			defer release()
 			varsInScope = treesitter.FindVariablesInScopeWithTree(tree.RootNode(), src, uint(lineNum), uint(col))
-			release()
 		}
 		for _, varName := range varsInScope {
 			if strings.HasPrefix(varName, funcPrefix) && !seen[varName] {


### PR DESCRIPTION
"Headless" LSP clients such as Claude Code don't actually open files when doing lookups or changing them. This means that some of our tricks for looking things up via the context of the files breaks.

This PR adds lazy disk-fallback to the document store so LSP clients that don't drive the full `didOpen`/`didChange`/`didClose` lifecycle (e.g. Claude Code) can still query definitions, hovers, references, and other text-dependent handlers. Use-injected lookups in particular: `lookupThroughUse`, `lookupThroughUseOf`. Alias merging also previously returned `nil` for any file the editor hadn't explicitly opened.

The goal of these changes is enablement work for a proper Claude Code plugin: https://github.com/remoteoss/dexter/pull/59.

## What changed

- **`DocumentStore.GetOrLoad(uri)`**: lazy disk read for any `file://` URI that isn't already in the store. Disk-loaded entries are marked `transient: true` and tracked in a Least Recently Used (LRU) cache. Non-`file://` URIs (e.g. `untitled:`) return `(false)` without touching disk to avoid the `uriToPath` panic.
- **LRU eviction**: transient entries are capped (default 50). Editor-owned buffers (`Set` via `didOpen`) are never counted, never reordered, never evicted. `Set` cleanly promotes a transient entry to editor-owned, dropping its LRU bookkeeping.
- **Cap is configurable**: new `maxTransientDocuments` initialization option (default 50, accepts integer or JSON number, clamps negatives to 0). Documented in `README.md`.
- **Handler migration**: 18 read-only handlers (`Definition`, `Hover`, `References`, `Completion`, `CodeAction`, `Declaration`, `DocumentHighlight`, `DocumentSymbol`, `FoldingRanges`, `Implementation`, `PrepareRename`, `Rename`, `SignatureHelp`, `TypeDefinition`, `PrepareCallHierarchy`, …) now call `GetOrLoad`. `Formatting` deliberately keeps `Get` — it only makes sense for in-memory editor buffers.

## Correctness notes

- File I/O happens outside the write lock; a re-check inside the lock returns the existing entry if a concurrent `Set` or `GetOrLoad` populated the URI first.
- `bumpLRU` is a no-op if the URI was promoted to editor-owned between the RLock and Lock, so the fast-path race is safe.
- `evictTransientLocked` closes the cached tree-sitter tree before deletion - no leak.
- Race-clean under `go test -race`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core document lifecycle, concurrent tree-sitter memory safety, and many LSP code paths; behavior change is intentional but wide in scope.
> 
> **Overview**
> Adds **lazy disk loading** for LSP documents so clients that never send `didOpen` (e.g. Claude Code) can still run definition, hover, references, completion, and related handlers. **`DocumentStore.GetOrLoad`** reads `file://` URIs from disk, marks them **transient**, and keeps them in an **LRU** (default cap 50, tunable via **`maxTransientDocuments`** in `initializationOptions`). **`didOpen`** buffers stay editor-owned: not counted, not evicted; **`Set`** promotes a transient entry and drops LRU tracking.
> 
> **`GetTree`** now returns a **`release`** callback and uses **refcounted** tree-sitter trees so LRU eviction cannot free C memory while another handler is walking the AST (fixes a use-after-free). **`GetIfOpen`** distinguishes real editor buffers from transient cache for **`readFileText`** / **`getFileLine`**. Most read-only handlers switched from **`Get`** to **`GetOrLoad`**; **formatting** still uses **`Get`** only. README documents the new option; broad tests cover LRU, promotion, and concurrent eviction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cf226665d56cb245172c380382db940e6b15812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->