### PR TITLE
Fix latent lint issues and ensure they're caught in future pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v7
-        with:
-          version: v2.11.4
-      - run: go mod tidy && git diff --exit-code go.mod go.sum
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+      - run: make lint

--- a/internal/lsp/documents_test.go
+++ b/internal/lsp/documents_test.go
@@ -168,6 +168,7 @@ func TestDocumentStore_Set_PromotesTransientToEditorOwned(t *testing.T) {
 	ds.mu.RUnlock()
 	if doc == nil {
 		t.Fatalf("entry missing after Set")
+		return
 	}
 	if doc.transient {
 		t.Fatalf("entry should be editor-owned after Set, still marked transient")
@@ -262,6 +263,7 @@ func TestDocumentStore_GetTree_DiskLoaded(t *testing.T) {
 	defer release()
 	if tree == nil {
 		t.Fatalf("GetTree returned nil tree")
+		return
 	}
 	if string(src) != contents {
 		t.Fatalf("GetTree src mismatch: got %q want %q", src, contents)
@@ -462,6 +464,7 @@ func TestDocumentStore_GetTree_SurvivesEviction(t *testing.T) {
 	}
 	if tree == nil {
 		t.Fatalf("GetTree returned nil tree")
+		return
 	}
 
 	// Capture the root node kind so we can re-read it after eviction.

--- a/internal/lsp/hover_test.go
+++ b/internal/lsp/hover_test.go
@@ -463,6 +463,7 @@ end`)
 	hover := hoverAt(t, server, uri, 3, 13)
 	if hover == nil {
 		t.Fatal("expected hover result")
+		return
 	}
 
 	content := hover.Contents.Value
@@ -495,6 +496,7 @@ end
 	hover := hoverAt(t, server, uri, 0, 8)
 	if hover == nil {
 		t.Fatal("expected hover result for module")
+		return
 	}
 
 	content := hover.Contents.Value
@@ -520,6 +522,7 @@ end
 	hover := hoverAt(t, server, uri, 0, 19)
 	if hover == nil {
 		t.Fatal("expected hover result even without doc")
+		return
 	}
 
 	content := hover.Contents.Value
@@ -551,6 +554,7 @@ end`
 	hover := hoverAt(t, server, uri, 8, 6)
 	if hover == nil {
 		t.Fatal("expected hover for local function")
+		return
 	}
 
 	content := hover.Contents.Value
@@ -588,6 +592,7 @@ end
 	hover := hoverAt(t, server, uri, 0, 7)
 	if hover == nil {
 		t.Fatal("expected hover for external module function")
+		return
 	}
 
 	content := hover.Contents.Value
@@ -633,6 +638,7 @@ end
 	hover := hoverAt(t, server, uri, 0, 11)
 	if hover == nil {
 		t.Fatal("expected hover for @type t")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "primary user struct") {
 		t.Errorf("expected typedoc in hover, got %q", hover.Contents.Value)
@@ -646,6 +652,7 @@ end
 	hover = hoverAt(t, server, uri, 0, 11)
 	if hover == nil {
 		t.Fatal("expected hover for @opaque token")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "opaque session token") {
 		t.Errorf("expected typedoc in hover, got %q", hover.Contents.Value)
@@ -705,6 +712,7 @@ end`)
 	hover := hoverAt(t, server, uri, 3, 2)
 	if hover == nil {
 		t.Fatal("expected hover for use-injected macro")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "Defines a schema with extended options") {
 		t.Errorf("expected doc for schema macro, got %q", hover.Contents.Value)
@@ -739,6 +747,7 @@ end`)
 	hover := hoverAt(t, server, uri, 4, 4)
 	if hover == nil {
 		t.Fatal("expected hover for use-injected inline def")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "double") {
 		t.Errorf("expected signature for inline def, got %q", hover.Contents.Value)
@@ -785,6 +794,7 @@ end`)
 	hover := hoverAt(t, server, uri, 3, 2)
 	if hover == nil {
 		t.Fatal("expected hover for double-use-injected macro")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "args_schema") {
 		t.Errorf("expected args_schema in hover, got %q", hover.Contents.Value)
@@ -845,6 +855,7 @@ end`)
 	hover := hoverAt(t, server, uri, 3, 2)
 	if hover == nil {
 		t.Fatal("expected hover for triple-use-chain with dynamic module")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "args_schema") {
 		t.Errorf("expected args_schema in hover, got %q", hover.Contents.Value)
@@ -893,6 +904,7 @@ end`)
 	hover := hoverAt(t, server, uri, 4, 4)
 	if hover == nil {
 		t.Fatal("expected hover for build_conn injected via CaseTemplate using_block delegation")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "build_conn") {
 		t.Errorf("expected build_conn in hover, got %q", hover.Contents.Value)
@@ -938,6 +950,7 @@ end`)
 	hover1 := hoverAt(t, server, uri1, 4, 4)
 	if hover1 == nil {
 		t.Fatal("expected hover for expect (default Mox)")
+		return
 	}
 	if !strings.Contains(hover1.Contents.Value, "Sets up an expectation") {
 		t.Errorf("expected Mox doc, got %q", hover1.Contents.Value)
@@ -955,6 +968,7 @@ end`)
 	hover2 := hoverAt(t, server, uri2, 4, 4)
 	if hover2 == nil {
 		t.Fatal("expected hover for expect (Hammox override)")
+		return
 	}
 	if !strings.Contains(hover2.Contents.Value, "type-checked") {
 		t.Errorf("expected Hammox doc, got %q", hover2.Contents.Value)
@@ -1028,6 +1042,7 @@ end`)
 	hover := hoverAt(t, server, uri, 3, 2)
 	if hover == nil {
 		t.Fatal("expected hover for args_schema with @doc since:")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "Define an args schema struct") {
 		t.Errorf("expected doc content before @doc since:, got %q", hover.Contents.Value)
@@ -1075,6 +1090,7 @@ end`
 	hover := hoverAt(t, server, uri, 3, 9)
 	if hover == nil {
 		t.Fatal("expected hover for __MODULE__")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "MyApp.Accounts") {
 		t.Errorf("expected module name in hover, got %q", hover.Contents.Value)
@@ -1106,6 +1122,7 @@ end`
 	hover := hoverAt(t, server, uri, 1, 20)
 	if hover == nil {
 		t.Fatal("expected hover for __MODULE__.User")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "MyApp.Accounts.User") {
 		t.Errorf("expected submodule in hover, got %q", hover.Contents.Value)
@@ -1143,6 +1160,7 @@ end`
 	hover := hoverAt(t, server, uri, 2, 4)
 	if hover == nil {
 		t.Fatal("expected hover for Accounts inside multi-line alias block")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "The Accounts context") {
 		t.Errorf("expected moduledoc in hover, got %q", hover.Contents.Value)
@@ -1152,6 +1170,7 @@ end`
 	hover = hoverAt(t, server, uri, 3, 4)
 	if hover == nil {
 		t.Fatal("expected hover for Users inside multi-line alias block")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "User management") {
 		t.Errorf("expected moduledoc in hover, got %q", hover.Contents.Value)
@@ -1168,6 +1187,7 @@ end`
 	hover = hoverAt(t, server, uri2, 2, 6)
 	if hover == nil {
 		t.Fatal("expected hover for module on line with trailing brace")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "The Accounts context") {
 		t.Errorf("expected moduledoc in hover, got %q", hover.Contents.Value)
@@ -1209,6 +1229,7 @@ end`)
 	hover := hoverAt(t, server, uri, 3, 15)
 	if hover == nil {
 		t.Fatal("expected hover for help() injected via multiline alias + import in __using__")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "def help") {
 		t.Errorf("expected help signature in hover, got %q", hover.Contents.Value)

--- a/internal/lsp/rename_test.go
+++ b/internal/lsp/rename_test.go
@@ -418,6 +418,7 @@ end
 	r := prepareRenameAt(t, server, docURI, 1, 6)
 	if r == nil {
 		t.Fatal("expected non-nil range")
+		return
 	}
 	if r.Start.Line != 1 {
 		t.Errorf("expected line 1, got %d", r.Start.Line)
@@ -447,6 +448,7 @@ end
 	r := prepareRenameAt(t, server, docURI, 0, 20)
 	if r == nil {
 		t.Fatal("expected non-nil range")
+		return
 	}
 	// Should highlight just "Accounts" (the last segment), not "MyApp.Accounts"
 	// "Accounts" starts at col 16, ends at col 24
@@ -820,6 +822,7 @@ end
 	rng := prepareRenameAt(t, server, docURI, 3, 10)
 	if rng == nil {
 		t.Fatal("expected PrepareRename to return a range for the variable")
+		return
 	}
 	// The highlighted range should be on line 3 (the variable), not line 6 (the function)
 	if rng.Start.Line != 3 {
@@ -1091,6 +1094,7 @@ end
 	r := prepareRenameAt(t, server, docURI, 4, 4)
 	if r == nil {
 		t.Fatal("expected PrepareRename to succeed for as: alias")
+		return
 	}
 	if r.Start.Line != 4 {
 		t.Errorf("expected highlight on line 4, got line %d", r.Start.Line)
@@ -1120,6 +1124,7 @@ end
 	r := prepareRenameAt(t, server, docURI, 5, 6)
 	if r == nil {
 		t.Fatal("expected PrepareRename to succeed for nested module function")
+		return
 	}
 	if r.Start.Line != 5 {
 		t.Errorf("expected highlight on line 5, got line %d", r.Start.Line)
@@ -1883,6 +1888,7 @@ end
 	r := prepareRenameAt(t, server, defURI, 0, 16)
 	if r == nil {
 		t.Fatal("expected non-nil prepareRename result")
+		return
 	}
 	// "CostCalculator" starts at col 16 in "defmodule MyApp.CostCalculator do"
 	if r.Start.Character != 16 {

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -1099,6 +1099,7 @@ end
 	}
 	if statusItem == nil {
 		t.Fatal("status item not found")
+		return
 	}
 	if statusItem.Kind != protocol.CompletionItemKindTypeParameter {
 		t.Errorf("expected TypeParameter kind for @type, got %v", statusItem.Kind)
@@ -3853,10 +3854,12 @@ end
 	child := findSymbol(parent.Children, "Child")
 	if child == nil {
 		t.Fatal("Child not found")
+		return
 	}
 	grandChild := findSymbol(child.Children, "GrandChild")
 	if grandChild == nil {
 		t.Fatal("GrandChild not found")
+		return
 	}
 	if findSymbol(grandChild.Children, "grandchild_func/0") == nil {
 		t.Error("grandchild_func/0 not found in GrandChild")
@@ -3884,6 +3887,7 @@ end
 	multiLine := findSymbol(mod.Children, "multi_line/1")
 	if multiLine == nil {
 		t.Fatal("multi_line/1 not found")
+		return
 	}
 	// multi_line should span from def line to end line (lines 1-3, 0-based)
 	if multiLine.Range.Start.Line != 1 {
@@ -3896,6 +3900,7 @@ end
 	inline := findSymbol(mod.Children, "inline/1")
 	if inline == nil {
 		t.Fatal("inline/1 not found")
+		return
 	}
 	// inline should be single-line (line 5, 0-based)
 	if inline.Range.Start.Line != 5 {
@@ -4006,6 +4011,7 @@ end
 	}
 	if privateFn == nil {
 		t.Fatal("expected defp build_user/1 as direct child of module")
+		return
 	}
 	if privateFn.Name != "build_user/1" {
 		t.Errorf("expected build_user/1, got %q", privateFn.Name)
@@ -4459,6 +4465,7 @@ end
 	outer := findSymbol(mod.Children, "outer/0")
 	if outer == nil {
 		t.Fatal("outer/0 not found")
+		return
 	}
 	if outer.Range.End.Line != 6 {
 		t.Errorf("outer end line: expected 6, got %d", outer.Range.End.Line)
@@ -4490,6 +4497,7 @@ end
 	split := findSymbol(mod.Children, "split/1")
 	if split == nil {
 		t.Fatal("split/1 not found")
+		return
 	}
 	if split.Range.Start.Line != 1 {
 		t.Errorf("split start line: expected 1, got %d", split.Range.Start.Line)
@@ -4681,6 +4689,7 @@ end`)
 	}
 	if result == nil {
 		t.Fatal("expected signature help result")
+		return
 	}
 	if len(result.Signatures) != 1 {
 		t.Fatalf("expected 1 signature, got %d", len(result.Signatures))
@@ -4724,6 +4733,7 @@ end`)
 	}
 	if result == nil {
 		t.Fatal("expected signature help for local function")
+		return
 	}
 	if result.Signatures[0].Label != "process(data, opts)" {
 		t.Errorf("unexpected label: %s", result.Signatures[0].Label)
@@ -4762,6 +4772,7 @@ end`)
 	}
 	if result == nil {
 		t.Fatal("expected signature help for nested call")
+		return
 	}
 	if result.Signatures[0].Label != "upcase(text)" {
 		t.Errorf("expected upcase(text), got: %s", result.Signatures[0].Label)
@@ -5479,6 +5490,7 @@ end`)
 	hover := hoverAt(t, server, uri, 2, 13)
 	if hover == nil {
 		t.Fatal("expected Elixir hover to still work")
+		return
 	}
 	if !strings.Contains(hover.Contents.Value, "Creates a new account") {
 		t.Errorf("expected doc content, got %q", hover.Contents.Value)


### PR DESCRIPTION
There were a bunch of lint errors, mainly about not having a `return` after a fatal error log, that we didn't catch due to the linter only running on the partial set of changes.

This PR:

- Fixes the lint issues.
- Changes the CI so that we always lint the entire codebase, rather than just the diffed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI-only changes; no production LSP or indexing behavior is modified.
> 
> **Overview**
> Fixes latent **golangci-lint** issues (mostly missing `return` after `t.Fatal` / `t.Fatalf` in LSP tests) and updates **CI** so lint always runs on the **full repo** via `make lint` (`golangci-lint run ./...`) instead of the GitHub Action that only covered changed files.
> 
> The workflow now installs **golangci-lint v2.11.4** with `go install` and invokes the same path as local development; test-only control-flow tweaks have no runtime impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae1f35c5fc8ff5b253eda9452a8c079c05de1368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->