### PR TITLE
Fix unbounded WAL growth in the index database

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -233,6 +233,13 @@ func (s *Server) backgroundReindex() {
 			}
 		}
 
+		// Collapse the WAL back to disk now that the (potentially large) reindex
+		// is complete, so the -wal file does not stay parked at its high-water
+		// mark for the lifetime of the LSP process.
+		if err := s.store.Checkpoint(); err != nil {
+			log.Printf("Warning: WAL checkpoint after reindex: %v", err)
+		}
+
 		elapsed := time.Since(start).Round(time.Millisecond)
 		log.Printf("Background reindex: %d files updated (%s)", reindexed, elapsed)
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,10 +7,39 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
-	_ "github.com/mattn/go-sqlite3"
+	sqlite3 "github.com/mattn/go-sqlite3"
 	"github.com/remoteoss/dexter/internal/parser"
 )
+
+// walSizeLimitBytes caps the on-disk size of the SQLite WAL file. SQLite does
+// not shrink the -wal file on its own: after a checkpoint it reuses the frames
+// in place, so without a size limit the file stays parked at its all-time
+// high-water mark forever (we have seen multi-GB -wal files from a single large
+// reindex). PRAGMA journal_size_limit tells SQLite to truncate the WAL back
+// down to this size after each checkpoint.
+const walSizeLimitBytes = 64 * 1024 * 1024 // 64 MiB
+
+// driverName is a SQLite driver variant registered with a ConnectHook that
+// applies journal_size_limit to every pooled connection. database/sql opens
+// connections lazily and may create new ones over the lifetime of the pool, so
+// a one-shot PRAGMA after Open would not cover later connections; the hook
+// guarantees every connection is capped.
+const driverName = "sqlite3_dexter"
+
+var registerDriverOnce sync.Once
+
+func registerDriver() {
+	registerDriverOnce.Do(func() {
+		sql.Register(driverName, &sqlite3.SQLiteDriver{
+			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				_, err := conn.Exec(fmt.Sprintf("PRAGMA journal_size_limit = %d", walSizeLimitBytes), nil)
+				return err
+			},
+		})
+	})
+}
 
 type Store struct {
 	db *sql.DB
@@ -83,7 +112,8 @@ func Open(projectRoot string) (*Store, error) {
 	}
 
 	dbPath := DBPath(projectRoot)
-	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000&_foreign_keys=ON")
+	registerDriver()
+	db, err := sql.Open(driverName, dbPath+"?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000&_foreign_keys=ON")
 	if err != nil {
 		return nil, err
 	}
@@ -123,11 +153,24 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
+// Checkpoint runs a TRUNCATE WAL checkpoint: it flushes committed WAL frames
+// into the main database file and then shrinks the -wal file back to zero
+// bytes. Call it after a large indexing pass so the WAL does not linger at its
+// high-water mark for the lifetime of the process. It is best-effort — if
+// another connection is mid-read the checkpoint may complete only partially,
+// in which case a later checkpoint (or the journal_size_limit applied on every
+// connection) reclaims the rest.
+func (s *Store) Checkpoint() error {
+	_, err := s.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	return err
+}
+
 // SetBulkPragmas configures SQLite for maximum write throughput. Safe only
 // when the database is fresh and throwaway-on-crash (e.g. a forced full
-// rebuild): synchronous=OFF skips all fsyncs, journal_mode=OFF eliminates
-// WAL writes entirely, a large cache keeps pages in RAM during index
-// creation, and temp_store=MEMORY keeps sort temporaries off disk.
+// rebuild): synchronous=OFF skips all fsyncs, journal_mode=MEMORY keeps the
+// rollback journal in RAM so no -wal file is written during the bulk load, a
+// large cache keeps pages in RAM during index creation, and temp_store=MEMORY
+// keeps sort temporaries off disk.
 func (s *Store) SetBulkPragmas() error {
 	for _, pragma := range []string{
 		"PRAGMA synchronous = OFF",

--- a/internal/store/wal_test.go
+++ b/internal/store/wal_test.go
@@ -1,0 +1,86 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/remoteoss/dexter/internal/parser"
+)
+
+// TestConnectionsHaveJournalSizeLimit verifies the ConnectHook applies
+// PRAGMA journal_size_limit to pooled connections. Without it, SQLite never
+// truncates the -wal file after a checkpoint and it grows without bound.
+func TestConnectionsHaveJournalSizeLimit(t *testing.T) {
+	s, _ := setupTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	var limit int64
+	if err := s.db.QueryRow("PRAGMA journal_size_limit").Scan(&limit); err != nil {
+		t.Fatal(err)
+	}
+	if limit != walSizeLimitBytes {
+		t.Fatalf("journal_size_limit = %d, want %d", limit, walSizeLimitBytes)
+	}
+}
+
+// TestCheckpointTruncatesWAL verifies that Checkpoint() collapses a populated
+// WAL back to zero bytes. This is the post-reindex reclaim that stops the
+// multi-GB -wal files we saw in the wild.
+func TestCheckpointTruncatesWAL(t *testing.T) {
+	s, dir := setupTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	// Write enough rows to push the WAL well past its empty size.
+	batch, err := s.BeginBatch()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3000; i++ {
+		path := fmt.Sprintf("%s/lib/f%d.ex", dir, i)
+		defs := []parser.Definition{{
+			Module:   fmt.Sprintf("MyApp.Mod%d", i),
+			Function: "run",
+			Arity:    1,
+			Kind:     "def",
+			Line:     1,
+			FilePath: path,
+		}}
+		if err := batch.IndexFileWithMtime(path, int64(i), defs); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := batch.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	walPath := DBPath(dir) + "-wal"
+	if info, err := os.Stat(walPath); err != nil || info.Size() == 0 {
+		t.Fatalf("expected a non-empty WAL before checkpoint (size err=%v)", err)
+	}
+
+	if err := s.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+
+	// TRUNCATE checkpoint with no concurrent readers shrinks the file to 0.
+	info, err := os.Stat(walPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return // removed entirely is also fine
+		}
+		t.Fatal(err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("WAL not truncated after Checkpoint: %d bytes", info.Size())
+	}
+
+	// Sanity: data survived the checkpoint (it was flushed into the main DB).
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM definitions").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 3000 {
+		t.Fatalf("expected 3000 definitions to survive checkpoint, got %d", count)
+	}
+}


### PR DESCRIPTION
WAL mode was enabled but journal_size_limit and checkpointing were never set, so the -wal file grew without bound (multi-GB+). 

Cap it per connection via a ConnectHook and run wal_checkpoint(TRUNCATE) after each reindex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local index cache behavior only; checkpoint failures are best-effort and logged without affecting LSP features.
> 
> **Overview**
> The index SQLite database used WAL mode without reclaiming space, so a large reindex could leave a multi‑gigabyte `-wal` file at its peak size for the rest of the LSP session.
> 
> **Store** now opens SQLite through a custom driver that sets `PRAGMA journal_size_limit` to 64 MiB on every pooled connection, and exposes `Checkpoint()` (`wal_checkpoint(TRUNCATE)`). Bulk rebuild pragmas are documented to use in-memory journaling so bulk loads do not grow a WAL file. **LSP** calls `Checkpoint()` after each background reindex finishes (errors are logged only).
> 
> Tests assert the journal size limit on connections and that checkpointing truncates a non-empty WAL while preserving indexed rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a230ef68ec04f1cd8c26970ddbdc06010d1fae32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->