### PR TITLE
Accept all formatter options from .formatter.exs

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,12 @@ Plugins ([`Styler`](https://github.com/remoteoss/elixir-styler), `Phoenix.LiveVi
 your project's `_build/dev/lib`. So as long as your formatter plugins are installed and compiled, everything is ready to
 go.
 
+**Non-standard formatter options:** Dexter passes your `.formatter.exs` options through to plugins as-is, matching `mix
+format`. So plugin-specific options like `Phoenix.LiveView.HTMLFormatter`'s `:heex_line_length`, `:attribute_formatters`,
+and `:inline_matcher` are honored. One caveat: the persistent process runs outside `Mix`, so a plugin that resolves
+config at format time via `Mix.*` or `Application.get_env/2` (e.g. `CanonicalTailwind` looking up its Tailwind binary)
+won't see it — inline that config directly in `.formatter.exs` instead (e.g. `canonical_tailwind: [binary: "PATH"]`).
+
 If the persistent process can't start, dexter falls back to running `mix format` directly.
 
 **Syntax errors** found by the formatter are surfaced as LSP diagnostics pointing to the exact line and column, with a warning at the hint location (e.g. "the `do` on line 52 does not have a matching `end`"). Diagnostics clear on the next successful format (which again, is nearly instantaneous!).

--- a/internal/lsp/beam_server.exs
+++ b/internal/lsp/beam_server.exs
@@ -170,14 +170,13 @@ defmodule Dexter.Formatter do
     explicit_locals = Keyword.get(raw_opts, :locals_without_parens, [])
     all_locals_without_parens = Enum.uniq(import_deps_locals ++ explicit_locals)
 
+    # Pass the full .formatter.exs through (minus our computed keys, set below)
+    # so non-standard options reach plugins, matching `mix format` behavior.
+    # `Code.format_string!/2` ignores options it doesn't recognize, and plugins
+    # such as Phoenix.LiveView.HTMLFormatter need keys like :attribute_formatters,
+    # :heex_line_length, :inline_matcher, and :migrate_eex_to_curly_interpolation.
     format_opts =
       raw_opts
-      |> Keyword.take([
-        :line_length,
-        :normalize_bitstring_modifiers,
-        :normalize_charlists_as_sigils,
-        :force_do_end_blocks
-      ])
       |> Keyword.put(:locals_without_parens, all_locals_without_parens)
 
     active_plugins = Enum.filter(plugins, &Code.ensure_loaded?/1)

--- a/internal/lsp/formatter_test.go
+++ b/internal/lsp/formatter_test.go
@@ -325,6 +325,104 @@ end
 	}
 }
 
+// createNonStandardOptionFixture builds a project whose .formatter.exs sets a
+// non-standard option (one outside the core Code.format_string!/2 set) and a
+// plugin that refuses to format unless that option is threaded through to its
+// opts. It guards against reintroducing an option allowlist in beam_server.exs.
+func createNonStandardOptionFixture(t *testing.T) string {
+	t.Helper()
+	mixRoot := t.TempDir()
+	for _, dir := range []string{"lib", "_build"} {
+		if err := os.MkdirAll(filepath.Join(mixRoot, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(
+		filepath.Join(mixRoot, "mix.exs"),
+		[]byte(`defmodule NonStandardOption.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :non_standard_option,
+      version: "0.1.0",
+      elixir: "~> 1.18"
+    ]
+  end
+end
+`),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(mixRoot, ".formatter.exs"),
+		[]byte("[plugins: [Dexter.MarkerFormatter], marker_option: \"THREADED\", inputs: [\"{lib,test}/**/*.{ex,exs,heex}\"]]\n"),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(mixRoot, "lib", "marker_formatter.ex"),
+		[]byte(`defmodule Dexter.MarkerFormatter do
+  def features(_opts), do: [extensions: [".heex"], sigils: [:H]]
+
+  def format(input, opts) do
+    case Keyword.get(opts, :marker_option) do
+      "THREADED" -> String.replace(input, "PLACEHOLDER", "THREADED")
+      other -> raise "marker_option not passed through, got: #{inspect(other)}"
+    end
+  end
+end
+`),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("mix", "compile")
+	cmd.Dir = mixRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("could not compile marker formatter fixture: %v\n%s", err, out)
+	}
+	return mixRoot
+}
+
+func TestFormatterServer_NonStandardOptionReachesPlugin(t *testing.T) {
+	if _, err := exec.LookPath("mix"); err != nil {
+		t.Skip("mix not available in PATH")
+	}
+
+	mixRoot := createNonStandardOptionFixture(t)
+	storeDir := t.TempDir()
+	s, err := store.Open(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+
+	server := NewServer(s, mixRoot)
+	if p, err := exec.LookPath("mix"); err == nil {
+		server.mixBin = p
+	}
+
+	filePath := filepath.Join(mixRoot, "lib", "component.heex")
+	docURI := string(uri.File(filePath))
+	server.docs.Set(docURI, "<div>PLACEHOLDER</div>\n")
+
+	edits, err := server.Formatting(context.Background(), &protocol.DocumentFormattingParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI(docURI)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edits == nil {
+		t.Fatal("expected formatting edits from marker formatter plugin, got nil")
+	}
+	if !strings.Contains(edits[0].NewText, "THREADED") {
+		t.Errorf("expected non-standard marker_option to reach plugin opts, got:\n%s", edits[0].NewText)
+	}
+}
+
 func TestFormatterServer_BasicProject(t *testing.T) {
 	if _, err := exec.LookPath("mix"); err != nil {
 		t.Skip("mix not available in PATH")


### PR DESCRIPTION
Closes #66.

## Problem

The formatter only forwarded a hardcoded allowlist of options from `.formatter.exs` (`:line_length`, `:normalize_bitstring_modifiers`, `:normalize_charlists_as_sigils`, `:force_do_end_blocks`). That stripped out plugin-specific options before they could reach plugins like `Phoenix.LiveView.HTMLFormatter` — e.g. `:attribute_formatters`, `:heex_line_length`, `:inline_matcher`, and `:migrate_eex_to_curly_interpolation`.

## Change

Drop the `Keyword.take/2` allowlist and pass the full `.formatter.exs` through, matching `mix format` behavior. Dexter's computed `:locals_without_parens` and `:sigils` are still `Keyword.put` on top, so there's no collision risk on the keys it derives itself.

This is low-risk: `Code.format_string!/2` silently ignores options it doesn't recognize (verified on Elixir 1.19.4), and plugins already receive `format_opts` and use `Keyword.get` internally. Since Dexter already `Code.eval_file`s the `.formatter.exs`, the allowlist was never a safety boundary.

## Tests

Adds `TestFormatterServer_NonStandardOptionReachesPlugin`: a fixture whose `.formatter.exs` sets a non-standard option and a plugin that raises unless that option reaches its `opts`. Confirmed it fails if any allowlist is reintroduced and passes with this change.

## Docs

README now documents that non-standard options pass through to plugins, plus the caveat that plugins resolving config via `Mix.*`/`Application.get_env/2` at format time (e.g. `CanonicalTailwind`) won't see it under the persistent process and must inline that config into `.formatter.exs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an option filter on the formatting path; core formatter still ignores unknown keys and computed options are unchanged.
> 
> **Overview**
> The persistent formatter in **`beam_server.exs`** no longer strips `.formatter.exs` to a small core option set. It forwards the full evaluated config into format/plugin calls (still merging computed `:locals_without_parens` and `:sigils`), aligning Dexter format-on-save with **`mix format`** for plugin-specific keys like HEEx options.
> 
> **README** documents that pass-through behavior and notes plugins that read **`Mix.*`** / **`Application.get_env/2`** at format time may need those values inlined in `.formatter.exs` when running outside Mix.
> 
> A new integration test uses a custom plugin that fails unless a non-standard `:marker_option` reaches its `format/2` opts, guarding against reintroducing an allowlist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23b8c686c78fadfd902d52df22ae8b180db74e00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->