### PR TITLE
Release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.7.1] - 2026-06-12
+
+### Added
+
+- **Structural completion snippets** — completions now include snippets for common Elixir forms such as `do`, `defmodule`, `def`, `defp`, `defmacro`, `defstruct`, `defprotocol`, `defimpl`, `defdelegate`, guards, `if`, `case`, `with`, `try`, and ExUnit-style macros; snippet-aware clients also avoid duplicate special-form completions when the same names are imported through `use`. This is an improvement and also fixes some VS Code usability issues do to how VS Code handles completions. Thanks @superhawk610.
+
+### Fixed
+
+- **Index WAL growing unchecked** — SQLite WAL files are capped and checkpointed after reindexing, preventing `.dexter/dexter.db-wal` from growing endlessly. Thanks @flowerett.
+- **Top-level script variables** — variables in `.exs` files such as `config/runtime.exs` can now be renamed and highlighted without leaking into nested module or function scopes
+- **Document symbols** — local assignments and ordinary function calls no longer appear in the outline, while split-line ExUnit-style macro heads are still shown correctly. Thanks @cjbottaro.
+- **Alias-aware import/use/require references** — short aliases in `import`, `use`, and `require` statements now resolve to the full module for references and rename edits
+- **Formatter improvements and fixes** — the persistent formatter server now starts Mix's supervisor tree so plugins can call Mix APIs like `Mix.Project.config/0`, and Dexter passes all `.formatter.exs` options through to formatter plugins so plugin-specific settings such as HEEX options are honored. Thanks @superhawk610 and @ogomezba.
+
 ## [0.7.0] - 2026-05-28
 
 ### Added

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "0.7.0"
+const Version = "0.7.1"
 
 // IndexVersion is incremented whenever the index schema or parser changes in a
 // way that requires a full rebuild. Bump this alongside Version when releasing


### PR DESCRIPTION
### Added

- **Structural completion snippets** — completions now include snippets for common Elixir forms such as `do`, `defmodule`, `def`, `defp`, `defmacro`, `defstruct`, `defprotocol`, `defimpl`, `defdelegate`, guards, `if`, `case`, `with`, `try`, and ExUnit-style macros; snippet-aware clients also avoid duplicate special-form completions when the same names are imported through `use`. This is an improvement and also fixes some VS Code usability issues do to how VS Code handles completions. Thanks @superhawk610.

### Fixed

- **Index WAL growing unchecked** — SQLite WAL files are capped and checkpointed after reindexing, preventing `.dexter/dexter.db-wal` from growing endlessly. Thanks @flowerett.
- **Top-level script variables** — variables in `.exs` files such as `config/runtime.exs` can now be renamed and highlighted without leaking into nested module or function scopes
- **Document symbols** — local assignments and ordinary function calls no longer appear in the outline, while split-line ExUnit-style macro heads are still shown correctly. Thanks @cjbottaro.
- **Alias-aware import/use/require references** — short aliases in `import`, `use`, and `require` statements now resolve to the full module for references and rename edits
- **Formatter improvements and fixes** — the persistent formatter server now starts Mix's supervisor tree so plugins can call Mix APIs like `Mix.Project.config/0`, and Dexter passes all `.formatter.exs` options through to formatter plugins so plugin-specific settings such as HEEX options are honored. Thanks @superhawk610 and @ogomezba.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only (version string and changelog); no application code changes in this diff.
> 
> **Overview**
> **Release v0.7.1** — bumps the published version from `0.7.0` to **`0.7.1`** in `internal/version/version.go` and documents the release in **`CHANGELOG.md`** (`IndexVersion` remains **12**, so this release does not flag an index rebuild by itself).
> 
> The changelog entry summarizes what ships in this tag: **structural completion snippets** for common Elixir forms (with deduping for snippet-aware clients), plus fixes for **SQLite WAL growth** after reindex, **top-level `.exs` variable** rename/highlight scope, **document symbol** outline noise, **alias-aware `import`/`use`/`require`** references, and **formatter server** Mix/plugin option passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df870d35acb0ce975b34916c655821f06fba6737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->