### PR TITLE
Change release CI flow to actually use our CHANGELOG.md notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,13 +74,26 @@ jobs:
           merge-multiple: true
       - name: Generate checksums
         run: cd artifacts && sha256sum *.tar.gz > checksums.txt
+      - name: Extract release notes
+        run: |
+          version="${RELEASE_TAG#v}"
+          awk -v version="$version" '
+            $0 ~ "^## \\[" version "\\]( - |$)" { in_section = 1; next }
+            in_section && /^## \[/ { exit }
+            in_section { print }
+          ' CHANGELOG.md > release-notes.md
+
+          if ! awk 'NF { found = 1 } END { exit !found }' release-notes.md; then
+            echo "No CHANGELOG.md notes found for ${RELEASE_TAG}"
+            exit 1
+          fi
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ env.RELEASE_TAG }}" \
             --title "${{ env.RELEASE_TAG }}" \
-            --generate-notes \
+            --notes-file release-notes.md \
             artifacts/*.tar.gz \
             artifacts/checksums.txt
 

--- a/README.md
+++ b/README.md
@@ -598,11 +598,11 @@ make release VERSION=0.2.0
 
 # 2. Push the branch and merge it into main
 
-# 3. Tag and push the tag
+# 3. Review CHANGELOG.md, then tag and push the tag
 make tag VERSION=0.2.0
 ```
 
-This updates the version in `internal/version/version.go` on a release branch. After merging to main, `make tag` creates and pushes the git tag. Users can then upgrade via mise:
+This updates the version in `internal/version/version.go` on a release branch. After merging to main, review the matching `CHANGELOG.md` entry because the GitHub release notes are published from that section. Then `make tag` creates and pushes the git tag. Users can then upgrade via mise:
 
 ```sh
 mise upgrade aqua:remoteoss/dexter


### PR DESCRIPTION
Our previous release flow was having GitHub's AI automatically generate the changelogs in the official release. These differed somewhat from our actual `CHANGELOG.md` notes. Because many automations rely on these Release notes as the main changelog, this change ensures that they're always in sync. Our current flow is to always push a changelog update before tagging and releasing, so this flow should work well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects release automation and maintainer docs; releases now fail fast if the changelog section is missing, which is intentional guardrail behavior.
> 
> **Overview**
> GitHub releases now publish **the same text as `CHANGELOG.md`** instead of auto-generated notes.
> 
> The release workflow adds an **Extract release notes** step that pulls the `## [version]` section for the tag (stripping the `v` prefix) into `release-notes.md`, and **fails the job** if that section is empty. `gh release create` then uses `--notes-file release-notes.md` instead of `--generate-notes`.
> 
> The **Releasing** section in the README tells maintainers to review the matching changelog entry before tagging, since that section becomes the official release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3703fb5e031a05c44011316b3b859282c49d8104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->