### PR TITLE
Upgrade CI actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - run: go test ./...
@@ -24,8 +24,8 @@ jobs:
   test-race:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - run: go test -race ./...
@@ -38,18 +38,18 @@ jobs:
       MIX_HOME: ${{ github.workspace }}/.mix
       HEX_HOME: ${{ github.workspace }}/.hex
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v5
+      - uses: actions/cache@v5
         with:
           path: .go/
           key: go-install-${{ hashFiles('go.sum') }}
           restore-keys: go-install-
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .gomod/
           key: go-mod-integration-${{ hashFiles('go.sum') }}
           restore-keys: go-mod-integration-
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             .mix/
@@ -79,8 +79,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Install golangci-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,10 @@ jobs:
     env:
       CGO_ENABLED: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.RELEASE_TAG }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Build
@@ -53,7 +53,7 @@ jobs:
           mkdir "$name"
           cp dexter "$name/"
           tar czf "${name}.tar.gz" "$name"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: dexter-${{ matrix.goos }}-${{ matrix.goarch }}
           path: "*.tar.gz"
@@ -63,11 +63,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: artifacts
           pattern: dexter-*
@@ -96,22 +96,3 @@ jobs:
             --notes-file release-notes.md \
             artifacts/*.tar.gz \
             artifacts/checksums.txt
-
-  update-homebrew:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-      - uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          pattern: dexter-*
-          merge-multiple: true
-      - name: Update Homebrew formula
-        env:
-          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          VERSION: ${{ env.RELEASE_TAG }}
-          ARTIFACTS_DIR: artifacts
-        run: scripts/update-homebrew-formula.sh


### PR DESCRIPTION
- GitLab CI is requiring that we upgrade to Node 24 in our actions. Fair enough!
- Removes the Homebrew tap version bump now that we're in main Homebrew.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes with no application code; the only behavioral change is that releases no longer auto-update a custom Homebrew tap.
> 
> **Overview**
> Bumps GitHub Actions across **CI** and **Release** to newer major versions (`checkout` v5, `setup-go` v6, `cache` v5, `upload-artifact` v6, `download-artifact` v7) to satisfy the Node 24 runtime requirement for those actions.
> 
> The **release** workflow no longer runs the **`update-homebrew`** job that checked out the tag, downloaded build artifacts, and invoked `scripts/update-homebrew-formula.sh` with `HOMEBREW_TAP_TOKEN`—releases still build, package, checksum, and publish via `gh release create` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0db9661579c916931c2b92b72a5356c05b89dd93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->