### PR TITLE
docs: document stdlib path override in Zed setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,22 @@ To override the binary path manually, add this to your `settings.json`:
 }
 ```
 
+If Zed shows a *"could not detect Elixir stdlib"* warning on startup — common when Elixir was installed via Homebrew, which ships no stdlib sources — point Dexter at an Elixir source tree matching your version (e.g. a checkout of [elixir-lang/elixir](https://github.com/elixir-lang/elixir)):
+
+```json
+{
+  "lsp": {
+    "dexter": {
+      "initialization_options": {
+        "stdlibPath": "/path/to/elixir/lib"
+      }
+    }
+  }
+}
+```
+
+Equivalently, set the `DEXTER_ELIXIR_LIB_ROOT` environment variable via `lsp.dexter.binary.env`.
+
 ### Emacs
 
 The emacs instructions assume you're using **use-package**.


### PR DESCRIPTION
Adds a short note to the Zed setup section covering the `Dexter: could not detect Elixir stdlib...` startup warning: how to point Dexter at a stdlib source tree via the `stdlibPath` initialization option (or `DEXTER_ELIXIR_LIB_ROOT` via `lsp.dexter.binary.env`).

Context: I hit this warning in Zed with a Homebrew-installed Elixir. Homebrew's `elixir` ships only compiled `.beam` files — no `.ex` sources (`find $(brew --prefix elixir) -name "*.ex"` comes back empty) — so auto-detection correctly rejects it (the `elixir/lib/enum.ex` check in `internal/stdlib/stdlib.go`), and pointing `DEXTER_ELIXIR_LIB_ROOT` at the Homebrew lib dir silences the warning without enabling stdlib navigation. What worked was a checkout of elixir-lang/elixir at the matching tag. Since the README's Zed section didn't mention either override, this documents them where Zed users will look.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior changes.
> 
> **Overview**
> **Extends the Zed editor setup** in the README with guidance for Dexter’s *“could not detect Elixir stdlib”* startup warning, especially when Elixir comes from Homebrew (no `.ex` stdlib sources).
> 
> The new section shows how to set **`stdlibPath`** under `lsp.dexter.initialization_options`, and notes the equivalent **`DEXTER_ELIXIR_LIB_ROOT`** override via `lsp.dexter.binary.env`, pointing users at a matching Elixir source tree (e.g. an `elixir-lang/elixir` checkout) for real stdlib navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbe2277c2624dd15c0b3622d7514c189faba9c34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->