### PR TITLE
Add dexter_rename_symbol MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **Built-in MCP server** - `dexter mcp` serves the index to AI agents over the Model Context Protocol (stdio, or streamable HTTP with `--listen`), modeled on `gopls mcp`. Nine tools cover workspace overview, fuzzy symbol search, definitions with docs and specs, references (including use-chain injected call sites), module API summaries, file outlines, behaviour/protocol implementations, call hierarchy, and incremental reindexing. The headless server watches the project tree (fsnotify) so the index stays fresh without editor events. A running LSP can expose the same tools from its live session via `dexter lsp --mcp-listen=ADDR`, and `dexter mcp --instructions` prints an agent-facing usage guide
+- **Built-in MCP server** - `dexter mcp` serves the index to AI agents over the Model Context Protocol (stdio, or streamable HTTP with `--listen`), modeled on `gopls mcp`. Ten tools cover workspace overview, fuzzy symbol search, definitions with docs and specs, references (including use-chain injected call sites), module API summaries, file outlines, behaviour/protocol implementations, call hierarchy, incremental reindexing, and workspace-wide rename returned as a unified diff for the agent to apply. The headless server watches the project tree (fsnotify) so the index stays fresh without editor events. A running LSP can expose the same tools from its live session via `dexter lsp --mcp-listen=ADDR`, and `dexter mcp --instructions` prints an agent-facing usage guide
 
 ## [0.7.1] - 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ When running as an LSP server, dexter automatically:
 
 ## MCP server
 
-Dexter includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) server, modeled on `gopls mcp`, so AI agents can navigate Elixir codebases through the index instead of grep. Tools cover symbol search, definitions with docs and specs, references, module API summaries, file outlines, behaviour/protocol implementations, call hierarchy, and incremental reindexing.
+Dexter includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) server, modeled on `gopls mcp`, so AI agents can navigate Elixir codebases through the index instead of grep. Tools cover symbol search, definitions with docs and specs, references, module API summaries, file outlines, behaviour/protocol implementations, call hierarchy, incremental reindexing, and workspace-wide rename (returned as a unified diff for the agent to review and apply).
 
 Register it with your MCP client. For Claude Code:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,8 @@ Dexter is a fast Elixir LSP server. It indexes module and function definitions f
 - `internal/store/` — SQLite layer. Tables: `files` (path + mtime), `definitions` (module, function, kind, line, file_path, delegate_to, delegate_as), `refs` (module, function, line, file_path, kind).
 - `internal/lsp/` — LSP server. `server.go` handles all LSP methods. `elixir.go` contains pure functions for cursor expression extraction, alias/import/use extraction (tokenizer-based), and use-chain parsing. `rename.go` has rename helpers. `hover.go` has hover formatting. `documents.go` is an in-memory open-buffer store.
 - `internal/treesitter/` — Tree-sitter integration for scope-aware variable rename and go-to-references.
-- `internal/mcp/` — Model Context Protocol server (`dexter mcp`). One file per tool, gopls-style; tools are name-based (module/function, not file+position) and call the store plus the exported facade in `internal/lsp/api.go`.
+- `internal/mcp/` — Model Context Protocol server (`dexter mcp`). One file per tool, gopls-style; tools are name-based (module/function, not file+position) and call the store plus the exported facade in `internal/lsp/api.go`. `internal/lsp/renameplan.go` computes renames as pure plans (shared with the LSP apply path) so the MCP rename tool can return a diff without writing.
+- `internal/diff/` — minimal line-based unified diff used by the MCP rename tool.
 
 ## LSP feature map
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -664,7 +664,7 @@ func TestIntegration_MCPStdio_EmptyIndexBuildsOnStartup(t *testing.T) {
 func TestIntegration_MCPInstructions(t *testing.T) {
 	binary := buildDexter(t)
 	out := runDexter(t, binary, t.TempDir(), "mcp", "--instructions")
-	for _, want := range []string{"dexter_workspace", "dexter_reindex"} {
+	for _, want := range []string{"dexter_workspace", "dexter_reindex", "dexter_rename_symbol"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("instructions missing %q", want)
 		}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,238 @@
+// Package diff renders unified diffs for the MCP rename tool. It is a small,
+// self-contained line-based LCS diff, not a general-purpose diff library.
+package diff
+
+import (
+	"fmt"
+	"strings"
+)
+
+const contextLines = 3
+
+// noEOL marks a final line that is not newline-terminated. It makes such a
+// line compare unequal to the same content with a newline (matching git
+// semantics) and tells the renderer to emit the "\ No newline" annotation.
+const noEOL = "\x00noeol"
+
+// Unified returns a unified diff between oldText and newText, labelled
+// `--- a/oldName` / `+++ b/newName`, or "" when the texts are equal. Missing
+// trailing newlines are annotated so standard tools (git apply, patch -p1)
+// can apply the output.
+func Unified(oldName, newName, oldText, newText string) string {
+	if oldText == newText {
+		return ""
+	}
+	oldLines := splitLines(oldText)
+	newLines := splitLines(newText)
+
+	ops := diffOps(oldLines, newLines)
+	hunks := buildHunks(ops)
+	if len(hunks) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "--- a/%s\n", oldName)
+	fmt.Fprintf(&b, "+++ b/%s\n", newName)
+	for _, h := range hunks {
+		oldCount := 0
+		newCount := 0
+		for _, op := range h.ops {
+			switch op.kind {
+			case opEqual:
+				oldCount++
+				newCount++
+			case opDelete:
+				oldCount++
+			case opInsert:
+				newCount++
+			}
+		}
+		fmt.Fprintf(&b, "@@ -%s +%s @@\n", hunkRange(h.oldStart, oldCount), hunkRange(h.newStart, newCount))
+		for _, op := range h.ops {
+			text, noNL := strings.CutSuffix(op.text, noEOL)
+			switch op.kind {
+			case opEqual:
+				b.WriteString(" " + text + "\n")
+			case opDelete:
+				b.WriteString("-" + text + "\n")
+			case opInsert:
+				b.WriteString("+" + text + "\n")
+			}
+			if noNL {
+				b.WriteString("\\ No newline at end of file\n")
+			}
+		}
+	}
+	return b.String()
+}
+
+// hunkRange renders a unified-diff range: "start,count", with count omitted
+// when it is 1 and start clamped for empty ranges.
+func hunkRange(start, count int) string {
+	if count == 1 {
+		return fmt.Sprintf("%d", start+1)
+	}
+	if count == 0 {
+		return fmt.Sprintf("%d,0", start)
+	}
+	return fmt.Sprintf("%d,%d", start+1, count)
+}
+
+// splitLines splits text into lines without terminators. A final line that is
+// not newline-terminated gets the noEOL sentinel appended.
+func splitLines(text string) []string {
+	if text == "" {
+		return nil
+	}
+	lines := strings.Split(text, "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1] // trailing newline: drop the phantom element
+	} else {
+		lines[len(lines)-1] += noEOL
+	}
+	return lines
+}
+
+type opKind int
+
+const (
+	opEqual opKind = iota
+	opDelete
+	opInsert
+)
+
+type diffOp struct {
+	kind opKind
+	text string
+}
+
+// diffOps computes an edit script via LCS with a trimmed common prefix/suffix
+// (keeps the DP table small for the typical rename diff: long files, few edits).
+func diffOps(oldLines, newLines []string) []diffOp {
+	prefix := 0
+	for prefix < len(oldLines) && prefix < len(newLines) && oldLines[prefix] == newLines[prefix] {
+		prefix++
+	}
+	suffix := 0
+	for suffix < len(oldLines)-prefix && suffix < len(newLines)-prefix &&
+		oldLines[len(oldLines)-1-suffix] == newLines[len(newLines)-1-suffix] {
+		suffix++
+	}
+
+	midOld := oldLines[prefix : len(oldLines)-suffix]
+	midNew := newLines[prefix : len(newLines)-suffix]
+
+	var ops []diffOp
+	for i := 0; i < prefix; i++ {
+		ops = append(ops, diffOp{opEqual, oldLines[i]})
+	}
+
+	// LCS table over the middle section.
+	n, m := len(midOld), len(midNew)
+	lcs := make([][]int, n+1)
+	for i := range lcs {
+		lcs[i] = make([]int, m+1)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if midOld[i] == midNew[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else if lcs[i+1][j] >= lcs[i][j+1] {
+				lcs[i][j] = lcs[i+1][j]
+			} else {
+				lcs[i][j] = lcs[i][j+1]
+			}
+		}
+	}
+	i, j := 0, 0
+	for i < n && j < m {
+		switch {
+		case midOld[i] == midNew[j]:
+			ops = append(ops, diffOp{opEqual, midOld[i]})
+			i++
+			j++
+		case lcs[i+1][j] >= lcs[i][j+1]:
+			ops = append(ops, diffOp{opDelete, midOld[i]})
+			i++
+		default:
+			ops = append(ops, diffOp{opInsert, midNew[j]})
+			j++
+		}
+	}
+	for ; i < n; i++ {
+		ops = append(ops, diffOp{opDelete, midOld[i]})
+	}
+	for ; j < m; j++ {
+		ops = append(ops, diffOp{opInsert, midNew[j]})
+	}
+
+	for k := 0; k < suffix; k++ {
+		ops = append(ops, diffOp{opEqual, oldLines[len(oldLines)-suffix+k]})
+	}
+	return ops
+}
+
+type hunk struct {
+	oldStart, newStart int // 0-based index of the first line in the hunk
+	ops                []diffOp
+}
+
+// buildHunks groups changed ops with surrounding context, coalescing hunks
+// whose context would overlap.
+func buildHunks(ops []diffOp) []hunk {
+	var hunks []hunk
+	i := 0
+	for i < len(ops) {
+		if ops[i].kind == opEqual {
+			i++
+			continue
+		}
+		// Found a change: back up for leading context.
+		start := i - contextLines
+		if start < 0 {
+			start = 0
+		}
+		// Extend through subsequent changes, allowing up to 2*contextLines of
+		// equal lines between changes before closing the hunk.
+		end := i
+		equalRun := 0
+		for j := i; j < len(ops); j++ {
+			if ops[j].kind == opEqual {
+				equalRun++
+				if equalRun > 2*contextLines {
+					break
+				}
+			} else {
+				equalRun = 0
+				end = j
+			}
+		}
+		stop := end + 1 + contextLines
+		if stop > len(ops) {
+			stop = len(ops)
+		}
+
+		h := hunk{ops: ops[start:stop]}
+		h.oldStart, h.newStart = hunkStart(ops, start)
+		hunks = append(hunks, h)
+		i = stop
+	}
+	return hunks
+}
+
+// hunkStart returns the old/new line indices at ops[start].
+func hunkStart(ops []diffOp, start int) (oldStart, newStart int) {
+	for _, op := range ops[:start] {
+		switch op.kind {
+		case opEqual:
+			oldStart++
+			newStart++
+		case opDelete:
+			oldStart++
+		case opInsert:
+			newStart++
+		}
+	}
+	return oldStart, newStart
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,120 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUnified_Equal(t *testing.T) {
+	if got := Unified("a.ex", "a.ex", "same\n", "same\n"); got != "" {
+		t.Errorf("equal texts produced a diff:\n%s", got)
+	}
+}
+
+func TestUnified_SimpleChange(t *testing.T) {
+	oldText := "defmodule Foo do\n  def bar, do: :ok\nend\n"
+	newText := "defmodule Foo do\n  def baz, do: :ok\nend\n"
+	got := Unified("lib/foo.ex", "lib/foo.ex", oldText, newText)
+	want := `--- a/lib/foo.ex
++++ b/lib/foo.ex
+@@ -1,3 +1,3 @@
+ defmodule Foo do
+-  def bar, do: :ok
++  def baz, do: :ok
+ end
+`
+	if got != want {
+		t.Errorf("diff mismatch.\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestUnified_EmptyToContent(t *testing.T) {
+	got := Unified("a.ex", "a.ex", "", "hello\n")
+	want := `--- a/a.ex
++++ b/a.ex
+@@ -0,0 +1 @@
++hello
+`
+	if got != want {
+		t.Errorf("diff mismatch.\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestUnified_RenameHeader(t *testing.T) {
+	got := Unified("lib/old.ex", "lib/new.ex", "defmodule Old do\nend\n", "defmodule New do\nend\n")
+	if !strings.HasPrefix(got, "--- a/lib/old.ex\n+++ b/lib/new.ex\n") {
+		t.Errorf("missing rename header:\n%s", got)
+	}
+}
+
+func TestUnified_DistantHunks(t *testing.T) {
+	var oldB, newB strings.Builder
+	for i := 0; i < 30; i++ {
+		line := "line\n"
+		oldB.WriteString(line)
+		newB.WriteString(line)
+	}
+	oldText := "first_old\n" + oldB.String() + "last_old\n"
+	newText := "first_new\n" + newB.String() + "last_new\n"
+	got := Unified("a.ex", "a.ex", oldText, newText)
+	if n := strings.Count(got, "@@ -"); n != 2 {
+		t.Errorf("want 2 hunks, got %d:\n%s", n, got)
+	}
+}
+
+func TestUnified_NoTrailingNewline(t *testing.T) {
+	cases := []struct {
+		name     string
+		old, new string
+		want     string
+	}{
+		{
+			name: "old lacks newline",
+			old:  "a\nb",
+			new:  "a\nb\nc\n",
+			want: `--- a/f
++++ b/f
+@@ -1,2 +1,3 @@
+ a
+-b
+\ No newline at end of file
++b
++c
+`,
+		},
+		{
+			name: "new lacks newline",
+			old:  "a\nb\n",
+			new:  "a\nb\nc",
+			want: `--- a/f
++++ b/f
+@@ -1,2 +1,3 @@
+ a
+ b
++c
+\ No newline at end of file
+`,
+		},
+		{
+			name: "both lack newline",
+			old:  "a\nb",
+			new:  "a\nc",
+			want: `--- a/f
++++ b/f
+@@ -1,2 +1,2 @@
+ a
+-b
+\ No newline at end of file
++c
+\ No newline at end of file
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Unified("f", "f", tc.old, tc.new); got != tc.want {
+				t.Errorf("diff mismatch.\ngot:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/lsp/renameplan.go
+++ b/internal/lsp/renameplan.go
@@ -1,0 +1,385 @@
+package lsp
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// This file computes renames as pure plans (the full new content of every
+// affected file) without touching disk. The LSP Rename handler and the MCP
+// dexter_rename_symbol tool share the same site collection and edit
+// application; only the final step differs (LSP writes/returns TextEdits, MCP
+// renders a diff). TestFunctionRenamePlan_MatchesApply and
+// TestModuleRenamePlan_MatchesApply keep the two paths in lockstep.
+
+// FileChange is one file's part of a RenamePlan.
+type FileChange struct {
+	Path    string // current path
+	NewPath string // non-empty when the file moves (conventional module rename)
+	OldText string
+	NewText string
+	Open    bool // file is open in the editor (attached mode only)
+}
+
+// RenamePlan is the complete effect of a rename, sorted by path.
+type RenamePlan struct {
+	Changes []FileChange
+}
+
+// FunctionRenamePlan computes the plan for renaming module.functionName to
+// newName across the workspace. It performs the same validation and collects
+// the same edit sites as the LSP rename, but writes nothing.
+func (s *Server) FunctionRenamePlan(module, functionName, newName string) (*RenamePlan, error) {
+	if !isValidFunctionName(newName) {
+		return nil, fmt.Errorf("invalid function name %q: must match [a-z_][a-z0-9_?!]*", newName)
+	}
+	defs, err := s.store.LookupFunction(module, functionName)
+	if err != nil {
+		return nil, err
+	}
+	if len(defs) == 0 {
+		return nil, fmt.Errorf("function %s.%s not found in the index", module, functionName)
+	}
+	if existing, err := s.store.LookupFunction(module, newName); err == nil && len(existing) > 0 {
+		return nil, fmt.Errorf("function %s.%s already exists", module, newName)
+	}
+
+	sites := s.collectFunctionRenameSites(module, functionName)
+
+	sitesByFile := make(map[string][]renameSite, len(sites))
+	for _, site := range sites {
+		sitesByFile[site.filePath] = append(sitesByFile[site.filePath], site)
+	}
+
+	changes := make(map[string]*FileChange, len(sitesByFile))
+	for fp, fileSites := range sitesByFile {
+		text, open, ok := s.ReadFileText(fp)
+		if !ok {
+			continue
+		}
+		lines := strings.Split(text, "\n")
+		newText := strings.Join(applyTokenEditsToLines(lines, fileSites, functionName, newName), "\n")
+		if newText == text {
+			continue
+		}
+		changes[fp] = &FileChange{Path: fp, OldText: text, NewText: newText, Open: open}
+	}
+
+	// Delegate `as:` updates apply on top of the token edits, mirroring the
+	// LSP path where they run after buildTextEdits has written files.
+	readLines := func(path string) ([]string, bool, bool) {
+		if fc, ok := changes[path]; ok {
+			return strings.Split(fc.NewText, "\n"), fc.Open, true
+		}
+		text, open, ok := s.ReadFileText(path)
+		if !ok {
+			return nil, false, false
+		}
+		return strings.Split(text, "\n"), open, true
+	}
+	for _, de := range s.delegateSpanEdits(module, functionName, newName, readLines) {
+		newText := strings.Join(spliceLines(de.fileLines, de.spanStart, de.spanEnd, de.updated), "\n")
+		if fc, ok := changes[de.filePath]; ok {
+			fc.NewText = newText
+			continue
+		}
+		oldText, _, ok := s.ReadFileText(de.filePath)
+		if !ok {
+			continue
+		}
+		changes[de.filePath] = &FileChange{Path: de.filePath, OldText: oldText, NewText: newText, Open: de.open}
+	}
+
+	return sortedPlan(changes), nil
+}
+
+// ModuleRenamePlan computes the plan for renaming oldModule (and its
+// submodules) to newModule, including conventional file moves. It performs the
+// same collision checks as the LSP rename, but writes nothing.
+func (s *Server) ModuleRenamePlan(oldModule, newModule string) (*RenamePlan, error) {
+	if !isValidModuleName(newModule) {
+		return nil, fmt.Errorf("invalid module name %q: must be CamelCase segments separated by dots", newModule)
+	}
+	if defs, err := s.store.LookupModule(oldModule); err != nil || len(defs) == 0 {
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("module %s not found in the index", oldModule)
+	}
+
+	mr := s.buildModuleRename(oldModule, newModule)
+	if err := mr.checkCollisions(); err != nil {
+		return nil, err
+	}
+	mr.collectSites()
+	fileCache := mr.readFiles()
+	return mr.plan(fileCache), nil
+}
+
+// plan renders the moduleRename as a RenamePlan: for every file with edit
+// sites, the fully-updated content, plus the conventional new path for files
+// that move. It reuses the exact edit application (applyEditsToLines) and path
+// computation (conventionalNewPath) the apply path uses.
+func (mr *moduleRename) plan(fileCache map[string]moduleFileInfo) *RenamePlan {
+	newPaths := make(map[string]string)
+	for _, r := range mr.allModuleDefs {
+		if _, ok := mr.moduleRenames[r.Module]; !ok {
+			continue
+		}
+		if newPath, follows := mr.conventionalNewPath(r); follows {
+			newPaths[r.FilePath] = newPath
+		}
+	}
+
+	changes := make(map[string]*FileChange, len(mr.sitesByFile))
+	for fp, sites := range mr.sitesByFile {
+		fi, ok := fileCache[fp]
+		if !ok {
+			continue
+		}
+		oldText := strings.Join(fi.lines, "\n")
+		newText := strings.Join(mr.applyEditsToLines(fi.lines, sites), "\n")
+		newPath := newPaths[fp]
+		if newText == oldText && newPath == "" {
+			continue
+		}
+		changes[fp] = &FileChange{Path: fp, NewPath: newPath, OldText: oldText, NewText: newText, Open: fi.open}
+	}
+	return sortedPlan(changes)
+}
+
+func sortedPlan(changes map[string]*FileChange) *RenamePlan {
+	plan := &RenamePlan{Changes: make([]FileChange, 0, len(changes))}
+	for _, fc := range changes {
+		plan.Changes = append(plan.Changes, *fc)
+	}
+	sort.Slice(plan.Changes, func(i, j int) bool { return plan.Changes[i].Path < plan.Changes[j].Path })
+	return plan
+}
+
+// collectFunctionRenameSites gathers every (file, line) that mentions
+// module.functionName and must be edited by a rename: definitions, indexed
+// references, transitive use-chain references, @spec/@callback lines, bare
+// intra-module calls, and `import Module, only: [...]` lines. Shared by the
+// LSP rename (which then applies edits) and FunctionRenamePlan.
+func (s *Server) collectFunctionRenameSites(module, functionName string) []renameSite {
+	type siteKey struct {
+		filePath string
+		line     int
+	}
+	seen := make(map[siteKey]bool)
+	var sites []renameSite
+
+	addSiteOpts := func(filePath string, line int, includeKeyword bool) {
+		if s.stdlibRoot != "" && strings.HasPrefix(filePath, s.stdlibRoot) {
+			return
+		}
+		if s.isDepsFile(filePath) {
+			return
+		}
+		k := siteKey{filePath, line}
+		if !seen[k] {
+			seen[k] = true
+			sites = append(sites, renameSite{filePath, line, includeKeyword})
+		}
+	}
+	addSite := func(filePath string, line int) {
+		addSiteOpts(filePath, line, false)
+	}
+
+	// Definition sites
+	defResults, err := s.store.LookupFunction(module, functionName)
+	if err != nil {
+		return nil
+	}
+	for _, r := range defResults {
+		addSite(r.FilePath, r.Line)
+	}
+
+	// Direct reference sites (calls, imports; skip alias/use which are module-level)
+	refResults, err := s.store.LookupReferences(module, functionName)
+	if err != nil {
+		return nil
+	}
+	for _, r := range refResults {
+		if r.Kind == "alias" || r.Kind == "use" {
+			continue
+		}
+		addSite(r.FilePath, r.Line)
+	}
+
+	// Transitive refs via __using__ chains
+	for _, mod := range s.findModulesWhoseUsingImports(module) {
+		transitive, err := s.store.LookupReferences(mod, functionName)
+		if err == nil {
+			for _, r := range transitive {
+				if r.Kind == "alias" || r.Kind == "use" {
+					continue
+				}
+				addSite(r.FilePath, r.Line)
+			}
+		}
+	}
+
+	// Collect definition file paths for file-scanning passes below
+	defFilePaths := make(map[string]bool)
+	for _, r := range defResults {
+		defFilePaths[r.FilePath] = true
+	}
+
+	// Scan definition files for @spec/@callback lines and bare intra-module calls
+	// (none of these are indexed in the store).
+	specPrefix := "@spec " + functionName
+	callbackPrefix := "@callback " + functionName
+	for filePath := range defFilePaths {
+		fileText, _, ok := s.ReadFileText(filePath)
+		if !ok {
+			continue
+		}
+		// @spec and @callback lines
+		for i, line := range strings.Split(fileText, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, specPrefix) {
+				rest := trimmed[len(specPrefix):]
+				if len(rest) == 0 || rest[0] == '(' || rest[0] == ' ' || rest[0] == '\t' {
+					addSite(filePath, i+1)
+				}
+			}
+			if strings.HasPrefix(trimmed, callbackPrefix) {
+				rest := trimmed[len(callbackPrefix):]
+				if len(rest) == 0 || rest[0] == '(' || rest[0] == ' ' || rest[0] == '\t' {
+					addSite(filePath, i+1)
+				}
+			}
+		}
+		// Bare calls: functionName(...) and |> functionName
+		for _, lineNum := range FindBareFunctionCalls(fileText, functionName) {
+			addSite(filePath, lineNum)
+		}
+	}
+
+	// Scan all files that import the module for `import Module, only: [functionName: N]` lines,
+	// then also scan those files for bare calls (which aren't indexed as references).
+	importRefs, _ := s.store.LookupReferences(module, "")
+	importFilePaths := make(map[string]bool)
+	for _, r := range importRefs {
+		if r.Kind != "import" {
+			continue
+		}
+		lineText, ok := s.FileLine(r.FilePath, r.Line)
+		if !ok {
+			continue
+		}
+		if findTokenColumn(lineText, functionName) >= 0 {
+			addSiteOpts(r.FilePath, r.Line, true)
+			importFilePaths[r.FilePath] = true
+		}
+	}
+	for filePath := range importFilePaths {
+		fileText, _, ok := s.ReadFileText(filePath)
+		if !ok {
+			continue
+		}
+		for _, lineNum := range FindBareFunctionCalls(fileText, functionName) {
+			addSite(filePath, lineNum)
+		}
+	}
+
+	return sites
+}
+
+// delegateSpanEdit is a computed update to a defdelegate facade that forwards
+// to a renamed function: the `as:` option is added or updated so the facade
+// keeps working. fileLines is the file content the span indices refer to.
+type delegateSpanEdit struct {
+	filePath  string
+	spanStart int // 0-based first line of the defdelegate span
+	spanEnd   int // exclusive
+	updated   []string
+	open      bool
+	fileLines []string
+}
+
+// delegateSpanEdits computes the defdelegate `as:` updates for a rename of
+// module.functionName to newName. readLines supplies the current lines of a
+// file (from disk on the apply path, from the in-progress plan on the plan
+// path) so both paths see the file state after token edits.
+func (s *Server) delegateSpanEdits(module, functionName, newName string, readLines func(string) (lines []string, open, ok bool)) []delegateSpanEdit {
+	if !s.followDelegates {
+		return nil
+	}
+	delegates, err := s.store.LookupDelegatesTo(module, functionName)
+	if err != nil {
+		return nil
+	}
+	var edits []delegateSpanEdit
+	for _, del := range delegates {
+		if s.stdlibRoot != "" && strings.HasPrefix(del.FilePath, s.stdlibRoot) {
+			continue
+		}
+		if s.isDepsFile(del.FilePath) {
+			continue
+		}
+		fileLines, open, ok := readLines(del.FilePath)
+		if !ok {
+			continue
+		}
+		startLine := del.Line - 1
+		if startLine >= len(fileLines) {
+			continue
+		}
+
+		updatedSpan, spanStart, spanEnd := updateDelegateAs(fileLines, startLine, del.Function, newName)
+		// Check if anything actually changed
+		changed := len(updatedSpan) != spanEnd-spanStart
+		if !changed {
+			for i, line := range updatedSpan {
+				if line != fileLines[spanStart+i] {
+					changed = true
+					break
+				}
+			}
+		}
+		if !changed {
+			continue
+		}
+		edits = append(edits, delegateSpanEdit{del.FilePath, spanStart, spanEnd, updatedSpan, open, fileLines})
+	}
+	return edits
+}
+
+// applyTokenEditsToLines applies right-to-left whole-token replacements for the
+// given sites, returning the updated lines. Shared by the LSP apply path
+// (buildTextEdits) and the plan path.
+func applyTokenEditsToLines(origLines []string, fileSites []renameSite, oldToken, newToken string) []string {
+	lines := make([]string, len(origLines))
+	copy(lines, origLines)
+
+	for _, site := range fileSites {
+		if site.line-1 >= len(lines) {
+			continue
+		}
+		lineText := lines[site.line-1]
+		var cols []int
+		if site.includeKeyword {
+			cols = findAllTokenColumns(lineText, oldToken)
+		} else {
+			cols = findFunctionTokenColumns(lineText, oldToken)
+		}
+		for i := len(cols) - 1; i >= 0; i-- {
+			lineText = lineText[:cols[i]] + newToken + lineText[cols[i]+len(oldToken):]
+		}
+		lines[site.line-1] = lineText
+	}
+	return lines
+}
+
+// spliceLines replaces lines[start:end] with replacement.
+func spliceLines(lines []string, start, end int, replacement []string) []string {
+	out := make([]string, 0, len(lines)-(end-start)+len(replacement))
+	out = append(out, lines[:start]...)
+	out = append(out, replacement...)
+	out = append(out, lines[end:]...)
+	return out
+}

--- a/internal/lsp/renameplan_test.go
+++ b/internal/lsp/renameplan_test.go
@@ -1,0 +1,269 @@
+package lsp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests are the regression guard for the rename plan/apply split: a plan
+// must predict exactly what the LSP apply path writes to disk. If the two ever
+// diverge, the MCP rename tool would hand agents diffs that don't match what
+// an editor rename produces.
+
+func TestFunctionRenamePlan_MatchesApply(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	fixtures := map[string]string{
+		"lib/accounts.ex": `defmodule MyApp.Accounts do
+  @doc """
+  Fetches a user.
+  """
+  @spec fetch_user(integer()) :: map()
+  def fetch_user(id) do
+    validate(id)
+    do_fetch(id)
+  end
+
+  def other_fun do
+    fetch_user(1)
+  end
+
+  defp validate(id), do: id
+  defp do_fetch(id), do: %{id: id}
+end
+`,
+		"lib/caller.ex": `defmodule MyApp.Caller do
+  def call do
+    MyApp.Accounts.fetch_user(42)
+  end
+end
+`,
+		"lib/importer.ex": `defmodule MyApp.Importer do
+  import MyApp.Accounts, only: [fetch_user: 1]
+
+  def go do
+    fetch_user(7)
+  end
+end
+`,
+		"lib/facade.ex": `defmodule MyApp.Facade do
+  defdelegate fetch_user(id), to: MyApp.Accounts
+end
+`,
+		"lib/unrelated.ex": `defmodule MyApp.Unrelated do
+  def nothing_here, do: :ok
+end
+`,
+	}
+	for rel, content := range fixtures {
+		indexFile(t, server.store, server.projectRoot, rel, content)
+	}
+
+	plan, err := server.FunctionRenamePlan("MyApp.Accounts", "fetch_user", "get_user")
+	if err != nil {
+		t.Fatalf("FunctionRenamePlan: %v", err)
+	}
+	if len(plan.Changes) == 0 {
+		t.Fatal("plan is empty")
+	}
+
+	// The plan must not have touched disk.
+	for rel, content := range fixtures {
+		data, err := os.ReadFile(filepath.Join(server.projectRoot, rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != content {
+			t.Fatalf("FunctionRenamePlan modified %s on disk", rel)
+		}
+	}
+
+	// Now run the LSP apply path (all files closed, so everything is written
+	// directly to disk).
+	if _, err := server.renameFunctionEdits("MyApp.Accounts", "fetch_user", "get_user"); err != nil {
+		t.Fatalf("renameFunctionEdits: %v", err)
+	}
+	server.backgroundWork.Wait()
+
+	// Every planned change must match the bytes the apply path wrote.
+	planned := make(map[string]FileChange, len(plan.Changes))
+	for _, fc := range plan.Changes {
+		if fc.NewPath != "" {
+			t.Errorf("function rename plan should not move files, got %s -> %s", fc.Path, fc.NewPath)
+		}
+		planned[fc.Path] = fc
+		data, err := os.ReadFile(fc.Path)
+		if err != nil {
+			t.Fatalf("reading %s after apply: %v", fc.Path, err)
+		}
+		if string(data) != fc.NewText {
+			t.Errorf("plan NewText for %s does not match applied content.\nplan:\n%s\napplied:\n%s", fc.Path, fc.NewText, data)
+		}
+	}
+
+	// And every file the apply path changed must be in the plan.
+	for rel, original := range fixtures {
+		path := filepath.Join(server.projectRoot, rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != original {
+			if _, ok := planned[path]; !ok {
+				t.Errorf("apply changed %s but the plan did not include it", rel)
+			}
+		}
+	}
+
+	// Sanity: the interesting sites were actually renamed.
+	mustContain := map[string][]string{
+		"lib/accounts.ex": {"def get_user(id)", "@spec get_user(integer())", "get_user(1)"},
+		"lib/caller.ex":   {"MyApp.Accounts.get_user(42)"},
+		"lib/importer.ex": {"only: [get_user: 1]", "get_user(7)"},
+		"lib/facade.ex":   {"as: :get_user"}, // delegate facade keeps its public name via as:
+	}
+	for rel, wants := range mustContain {
+		data, _ := os.ReadFile(filepath.Join(server.projectRoot, rel))
+		for _, w := range wants {
+			if !strings.Contains(string(data), w) {
+				t.Errorf("%s missing %q after rename:\n%s", rel, w, data)
+			}
+		}
+	}
+}
+
+func TestModuleRenamePlan_MatchesApply(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	fixtures := map[string]string{
+		"lib/my_app/companies.ex": `defmodule MyApp.Companies do
+  def list, do: []
+end
+`,
+		"lib/my_app/companies/finder.ex": `defmodule MyApp.Companies.Finder do
+  def find(id), do: id
+end
+`,
+		"lib/my_app/consumer.ex": `defmodule MyApp.Consumer do
+  alias MyApp.Companies
+  alias MyApp.Companies.Finder
+
+  def go do
+    Companies.list()
+    Finder.find(1)
+  end
+end
+`,
+	}
+	for rel, content := range fixtures {
+		indexFile(t, server.store, server.projectRoot, rel, content)
+	}
+
+	plan, err := server.ModuleRenamePlan("MyApp.Companies", "MyApp.Clients")
+	if err != nil {
+		t.Fatalf("ModuleRenamePlan: %v", err)
+	}
+
+	// The plan must not have touched disk.
+	for rel, content := range fixtures {
+		data, err := os.ReadFile(filepath.Join(server.projectRoot, rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != content {
+			t.Fatalf("ModuleRenamePlan modified %s on disk", rel)
+		}
+	}
+
+	// The conventional files must be planned as moves.
+	moves := make(map[string]string)
+	for _, fc := range plan.Changes {
+		if fc.NewPath != "" {
+			moves[fc.Path] = fc.NewPath
+		}
+	}
+	wantMoves := map[string]string{
+		filepath.Join(server.projectRoot, "lib/my_app/companies.ex"):        filepath.Join(server.projectRoot, "lib/my_app/clients.ex"),
+		filepath.Join(server.projectRoot, "lib/my_app/companies/finder.ex"): filepath.Join(server.projectRoot, "lib/my_app/clients/finder.ex"),
+	}
+	for from, to := range wantMoves {
+		if moves[from] != to {
+			t.Errorf("plan move for %s = %q, want %q", from, moves[from], to)
+		}
+	}
+
+	// Apply via the LSP path.
+	if _, err := server.renameModuleEdits(context.Background(), "MyApp.Companies", "MyApp.Clients", ""); err != nil {
+		t.Fatalf("renameModuleEdits: %v", err)
+	}
+	server.backgroundWork.Wait()
+
+	for _, fc := range plan.Changes {
+		finalPath := fc.Path
+		if fc.NewPath != "" {
+			finalPath = fc.NewPath
+			if _, err := os.Stat(fc.Path); !os.IsNotExist(err) {
+				t.Errorf("old path %s still exists after apply", fc.Path)
+			}
+		}
+		data, err := os.ReadFile(finalPath)
+		if err != nil {
+			t.Fatalf("reading %s after apply: %v", finalPath, err)
+		}
+		if string(data) != fc.NewText {
+			t.Errorf("plan NewText for %s does not match applied content.\nplan:\n%s\napplied:\n%s", finalPath, fc.NewText, data)
+		}
+	}
+
+	// Consumer aliases must have been rewritten.
+	data, _ := os.ReadFile(filepath.Join(server.projectRoot, "lib/my_app/consumer.ex"))
+	for _, w := range []string{"alias MyApp.Clients", "alias MyApp.Clients.Finder", "Clients.list()"} {
+		if !strings.Contains(string(data), w) {
+			t.Errorf("consumer missing %q after rename:\n%s", w, data)
+		}
+	}
+}
+
+func TestFunctionRenamePlan_Validation(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	indexFile(t, server.store, server.projectRoot, "lib/accounts.ex", `defmodule MyApp.Accounts do
+  def fetch_user(id), do: id
+  def get_user(id), do: id
+end
+`)
+
+	if _, err := server.FunctionRenamePlan("MyApp.Accounts", "fetch_user", "NotAFunction"); err == nil {
+		t.Error("invalid new name accepted")
+	}
+	if _, err := server.FunctionRenamePlan("MyApp.Accounts", "fetch_user", "get_user"); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("collision not detected: %v", err)
+	}
+	if _, err := server.FunctionRenamePlan("MyApp.Accounts", "no_such_fun", "whatever"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("missing function not detected: %v", err)
+	}
+}
+
+func TestModuleRenamePlan_Validation(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	indexFile(t, server.store, server.projectRoot, "lib/a.ex", "defmodule MyApp.A do\nend\n")
+	indexFile(t, server.store, server.projectRoot, "lib/b.ex", "defmodule MyApp.B do\nend\n")
+
+	if _, err := server.ModuleRenamePlan("MyApp.A", "not_a_module"); err == nil {
+		t.Error("invalid module name accepted")
+	}
+	if _, err := server.ModuleRenamePlan("MyApp.A", "MyApp.B"); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("collision not detected: %v", err)
+	}
+	if _, err := server.ModuleRenamePlan("MyApp.Missing", "MyApp.New"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("missing module not detected: %v", err)
+	}
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -4197,189 +4197,37 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 // renameFunctionEdits builds a WorkspaceEdit renaming all occurrences of
 // module.functionName to newName across the codebase.
 func (s *Server) renameFunctionEdits(module, functionName, newName string) (*protocol.WorkspaceEdit, error) {
-	// Collect all (filePath, lineNumber) pairs — definitions + references
-	type siteKey struct {
-		filePath string
-		line     int
-	}
-	seen := make(map[siteKey]bool)
-	var sites []renameSite
-
-	addSiteOpts := func(filePath string, line int, includeKeyword bool) {
-		if s.stdlibRoot != "" && strings.HasPrefix(filePath, s.stdlibRoot) {
-			return
-		}
-		if s.isDepsFile(filePath) {
-			return
-		}
-		k := siteKey{filePath, line}
-		if !seen[k] {
-			seen[k] = true
-			sites = append(sites, renameSite{filePath, line, includeKeyword})
-		}
-	}
-	addSite := func(filePath string, line int) {
-		addSiteOpts(filePath, line, false)
-	}
-
-	// Definition sites
-	defResults, err := s.store.LookupFunction(module, functionName)
-	if err != nil {
-		return nil, nil
-	}
-	for _, r := range defResults {
-		addSite(r.FilePath, r.Line)
-	}
-
-	// Direct reference sites (calls, imports — skip alias/use which are module-level)
-	refResults, err := s.store.LookupReferences(module, functionName)
-	if err != nil {
-		return nil, nil
-	}
-	for _, r := range refResults {
-		if r.Kind == "alias" || r.Kind == "use" {
-			continue
-		}
-		addSite(r.FilePath, r.Line)
-	}
-
-	// Transitive refs via __using__ chains
-	for _, mod := range s.findModulesWhoseUsingImports(module) {
-		transitive, err := s.store.LookupReferences(mod, functionName)
-		if err == nil {
-			for _, r := range transitive {
-				if r.Kind == "alias" || r.Kind == "use" {
-					continue
-				}
-				addSite(r.FilePath, r.Line)
-			}
-		}
-	}
-
-	// Collect definition file paths for file-scanning passes below
-	defFilePaths := make(map[string]bool)
-	for _, r := range defResults {
-		defFilePaths[r.FilePath] = true
-	}
-
-	// Scan definition files for @spec/@callback lines and bare intra-module calls
-	// (none of these are indexed in the store).
-	specPrefix := "@spec " + functionName
-	callbackPrefix := "@callback " + functionName
-	for filePath := range defFilePaths {
-		fileText, _, ok := s.ReadFileText(filePath)
-		if !ok {
-			continue
-		}
-		// @spec and @callback lines
-		for i, line := range strings.Split(fileText, "\n") {
-			trimmed := strings.TrimSpace(line)
-			if strings.HasPrefix(trimmed, specPrefix) {
-				rest := trimmed[len(specPrefix):]
-				if len(rest) == 0 || rest[0] == '(' || rest[0] == ' ' || rest[0] == '\t' {
-					addSite(filePath, i+1)
-				}
-			}
-			if strings.HasPrefix(trimmed, callbackPrefix) {
-				rest := trimmed[len(callbackPrefix):]
-				if len(rest) == 0 || rest[0] == '(' || rest[0] == ' ' || rest[0] == '\t' {
-					addSite(filePath, i+1)
-				}
-			}
-		}
-		// Bare calls: functionName(...) and |> functionName
-		for _, lineNum := range FindBareFunctionCalls(fileText, functionName) {
-			addSite(filePath, lineNum)
-		}
-	}
-
-	// Scan all files that import the module for `import Module, only: [functionName: N]` lines,
-	// then also scan those files for bare calls (which aren't indexed as references).
-	importRefs, _ := s.store.LookupReferences(module, "")
-	importFilePaths := make(map[string]bool)
-	for _, r := range importRefs {
-		if r.Kind != "import" {
-			continue
-		}
-		lineText, ok := s.FileLine(r.FilePath, r.Line)
-		if !ok {
-			continue
-		}
-		if findTokenColumn(lineText, functionName) >= 0 {
-			addSiteOpts(r.FilePath, r.Line, true)
-			importFilePaths[r.FilePath] = true
-		}
-	}
-	for filePath := range importFilePaths {
-		fileText, _, ok := s.ReadFileText(filePath)
-		if !ok {
-			continue
-		}
-		for _, lineNum := range FindBareFunctionCalls(fileText, functionName) {
-			addSite(filePath, lineNum)
-		}
-	}
+	sites := s.collectFunctionRenameSites(module, functionName)
 
 	edit := s.buildTextEdits(sites, functionName, newName)
 
 	// Update defdelegate lines that forward to this function: add or update
-	// the `as:` option so the facade keeps working after the rename.
-	if s.followDelegates {
-		delegates, err := s.store.LookupDelegatesTo(module, functionName)
-		if err == nil {
-			for _, del := range delegates {
-				if s.stdlibRoot != "" && strings.HasPrefix(del.FilePath, s.stdlibRoot) {
-					continue
-				}
-				if s.isDepsFile(del.FilePath) {
-					continue
-				}
-				fileText, open, ok := s.ReadFileText(del.FilePath)
-				if !ok {
-					continue
-				}
-				fileLines := strings.Split(fileText, "\n")
-				startLine := del.Line - 1
-				if startLine >= len(fileLines) {
-					continue
-				}
-
-				updatedSpan, spanStart, spanEnd := updateDelegateAs(fileLines, startLine, del.Function, newName)
-				// Check if anything actually changed
-				changed := len(updatedSpan) != spanEnd-spanStart
-				if !changed {
-					for i, line := range updatedSpan {
-						if line != fileLines[spanStart+i] {
-							changed = true
-							break
-						}
-					}
-				}
-				if !changed {
-					continue
-				}
-
-				fileURI := protocol.DocumentURI(uri.File(del.FilePath))
-				if open {
-					if edit.Changes == nil {
-						edit.Changes = make(map[protocol.DocumentURI][]protocol.TextEdit)
-					}
-					edit.Changes[fileURI] = append(edit.Changes[fileURI], protocol.TextEdit{
-						Range: protocol.Range{
-							Start: protocol.Position{Line: uint32(spanStart), Character: 0},
-							End:   protocol.Position{Line: uint32(spanEnd - 1), Character: uint32(len(fileLines[spanEnd-1]))},
-						},
-						NewText: strings.Join(updatedSpan, "\n"),
-					})
-				} else {
-					// Closed file: splice updated span into file lines and write back
-					newFileLines := make([]string, 0, len(fileLines)-spanEnd+spanStart+len(updatedSpan))
-					newFileLines = append(newFileLines, fileLines[:spanStart]...)
-					newFileLines = append(newFileLines, updatedSpan...)
-					newFileLines = append(newFileLines, fileLines[spanEnd:]...)
-					_ = os.WriteFile(del.FilePath, []byte(strings.Join(newFileLines, "\n")), 0644)
-				}
+	// the `as:` option so the facade keeps working after the rename. This runs
+	// after buildTextEdits so the spans are computed on post-edit file state.
+	readLines := func(path string) ([]string, bool, bool) {
+		fileText, open, ok := s.ReadFileText(path)
+		if !ok {
+			return nil, false, false
+		}
+		return strings.Split(fileText, "\n"), open, true
+	}
+	for _, de := range s.delegateSpanEdits(module, functionName, newName, readLines) {
+		fileURI := protocol.DocumentURI(uri.File(de.filePath))
+		if de.open {
+			if edit.Changes == nil {
+				edit.Changes = make(map[protocol.DocumentURI][]protocol.TextEdit)
 			}
+			edit.Changes[fileURI] = append(edit.Changes[fileURI], protocol.TextEdit{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: uint32(de.spanStart), Character: 0},
+					End:   protocol.Position{Line: uint32(de.spanEnd - 1), Character: uint32(len(de.fileLines[de.spanEnd-1]))},
+				},
+				NewText: strings.Join(de.updated, "\n"),
+			})
+		} else {
+			// Closed file: splice updated span into file lines and write back
+			newFileLines := spliceLines(de.fileLines, de.spanStart, de.spanEnd, de.updated)
+			_ = os.WriteFile(de.filePath, []byte(strings.Join(newFileLines, "\n")), 0644)
 		}
 	}
 
@@ -4909,31 +4757,6 @@ func (s *Server) buildTextEdits(sites []renameSite, oldToken, newToken string) *
 		}
 	}
 
-	// applyTokenEdits applies right-to-left token replacements for the given
-	// sites, returning the updated lines. Shared by open and closed file paths.
-	applyTokenEdits := func(origLines []string, fileSites []renameSite) []string {
-		lines := make([]string, len(origLines))
-		copy(lines, origLines)
-
-		for _, site := range fileSites {
-			if site.line-1 >= len(lines) {
-				continue
-			}
-			lineText := lines[site.line-1]
-			var cols []int
-			if site.includeKeyword {
-				cols = findAllTokenColumns(lineText, oldToken)
-			} else {
-				cols = findFunctionTokenColumns(lineText, oldToken)
-			}
-			for i := len(cols) - 1; i >= 0; i-- {
-				lineText = lineText[:cols[i]] + newToken + lineText[cols[i]+len(oldToken):]
-			}
-			lines[site.line-1] = lineText
-		}
-		return lines
-	}
-
 	openChanges := make(map[protocol.DocumentURI][]protocol.TextEdit)
 	var wg sync.WaitGroup
 	var reindexPaths []string
@@ -4950,7 +4773,7 @@ func (s *Server) buildTextEdits(sites []renameSite, oldToken, newToken string) *
 		}
 
 		// Compute edits once for both TextEdits and reindexing
-		updatedLines := applyTokenEdits(fi.lines, fileSites)
+		updatedLines := applyTokenEditsToLines(fi.lines, fileSites, oldToken, newToken)
 
 		if fi.open {
 			// Open buffer: build TextEdits for the editor AND capture updated

--- a/internal/mcp/instructions.md
+++ b/internal/mcp/instructions.md
@@ -15,10 +15,14 @@ Which tool for which question:
 - Implementations of a behaviour or protocol: `dexter_implementations`
 - What a specific file defines: `dexter_file_outline`
 - Project layout and index freshness: `dexter_workspace`
+- Rename a module or function everywhere: `dexter_rename_symbol`
 
 The index updates automatically: file changes are watched (fsnotify) and git
 branch switches are detected. If a lookup ever seems stale, `dexter_reindex`
 forces an immediate incremental update.
+
+`dexter_rename_symbol` writes nothing: apply the returned diff yourself,
+perform the listed file renames, then call `dexter_reindex`.
 
 Elixir specifics: modules are not tied to files (use `dexter_file_outline` for
 a file, `dexter_definition` for a module); pass fully-qualified module names,

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -112,6 +112,12 @@ func NewServer(h *Handler) *mcp.Server {
 		Description: "Force an immediate incremental reindex. The index already updates automatically as files change; use this only when a lookup seems stale. The only tool that writes, and it writes only dexter's own index database.",
 	}, h.reindexHandler)
 
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "dexter_rename_symbol",
+		Annotations: readOnly,
+		Description: "Rename an Elixir module or function across the whole workspace. Returns the change as a unified diff plus file renames; nothing is written until you apply it. Apply the diff, perform the file renames, then call dexter_reindex.",
+	}, h.renameHandler)
+
 	return srv
 }
 

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -145,6 +145,7 @@ func TestListTools(t *testing.T) {
 		"dexter_module_api",
 		"dexter_references",
 		"dexter_reindex",
+		"dexter_rename_symbol",
 		"dexter_search",
 		"dexter_workspace",
 	}

--- a/internal/mcp/rename.go
+++ b/internal/mcp/rename.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/remoteoss/dexter/internal/diff"
+	"github.com/remoteoss/dexter/internal/lsp"
+)
+
+type RenameParams struct {
+	Module   string `json:"module" jsonschema:"module being renamed, or the module owning the function"`
+	Function string `json:"function,omitempty" jsonschema:"if set, rename this function; otherwise rename the module itself (and its submodules)"`
+	NewName  string `json:"new_name" jsonschema:"new function name (e.g. get_user), or new fully-qualified module name (e.g. MyApp.Clients)"`
+}
+
+func (h *Handler) renameHandler(ctx context.Context, req *mcp.CallToolRequest, args RenameParams) (*mcp.CallToolResult, any, error) {
+	module := strings.TrimSpace(args.Module)
+	function := strings.TrimSpace(args.Function)
+	newName := strings.TrimSpace(args.NewName)
+	if module == "" || newName == "" {
+		return nil, nil, fmt.Errorf("module and new_name must not be empty")
+	}
+
+	var plan *lsp.RenamePlan
+	var err error
+	var target string
+	if function != "" {
+		target = fmt.Sprintf("function %s.%s to %s", module, function, newName)
+		plan, err = h.lsp.FunctionRenamePlan(module, function, newName)
+	} else {
+		target = fmt.Sprintf("module %s to %s", module, newName)
+		plan, err = h.lsp.ModuleRenamePlan(module, newName)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(plan.Changes) == 0 {
+		return textResult(fmt.Sprintf("Renaming %s requires no changes (no occurrences found outside stdlib/deps).", target)), nil, nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Rename %s: %d file(s) affected. Nothing has been written; apply the changes below, then call dexter_reindex.\n", target, len(plan.Changes))
+
+	var renames []string
+	for _, fc := range plan.Changes {
+		if fc.NewPath != "" {
+			renames = append(renames, fmt.Sprintf("RENAME %s → %s", h.relPath(fc.Path), h.relPath(fc.NewPath)))
+		}
+	}
+	if len(renames) > 0 {
+		fmt.Fprintf(&b, "\nFile renames (the diffs below are written against the NEW paths; move each file first, then apply):\n")
+		for _, r := range renames {
+			fmt.Fprintf(&b, "  %s\n", r)
+		}
+	}
+
+	b.WriteString("\n")
+	for _, fc := range plan.Changes {
+		// For moved files the diff is addressed at the NEW path on both sides:
+		// perform the file rename first, then the patch applies cleanly (plain
+		// unified diffs can't express renames portably).
+		name := h.relPath(fc.Path)
+		if fc.NewPath != "" {
+			name = h.relPath(fc.NewPath)
+		}
+		if d := diff.Unified(name, name, fc.OldText, fc.NewText); d != "" {
+			b.WriteString(d)
+		}
+	}
+	return textResult(b.String()), nil, nil
+}

--- a/internal/mcp/rename_test.go
+++ b/internal/mcp/rename_test.go
@@ -1,0 +1,117 @@
+package mcp
+
+import (
+	"crypto/sha256"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// hashTree fingerprints every regular file under root except dexter's own
+// index database (the store legitimately writes there).
+func hashTree(t *testing.T, root string) map[string][32]byte {
+	t.Helper()
+	hashes := make(map[string][32]byte)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".dexter" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		hashes[path] = sha256.Sum256(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hashes
+}
+
+func TestRenameTool_FunctionDiff(t *testing.T) {
+	e := setupProject(t)
+	out := e.callTool("dexter_rename_symbol", map[string]any{
+		"module": "MyApp.Accounts", "function": "fetch_user", "new_name": "get_user",
+	})
+	wantContains(t, out,
+		"Rename function MyApp.Accounts.fetch_user to get_user",
+		"Nothing has been written",
+		"--- a/lib/my_app/accounts.ex",
+		"+++ b/lib/my_app/accounts.ex",
+		"-  def fetch_user(id) do",
+		"+  def get_user(id) do",
+		"-  @spec fetch_user(integer())",
+		"+  @spec get_user(integer())",
+		"--- a/lib/my_app/worker.ex",
+		"-    MyApp.Accounts.fetch_user(1)",
+		"+    MyApp.Accounts.get_user(1)",
+		"dexter_reindex",
+	)
+}
+
+func TestRenameTool_ModuleDiff_WithFileRename(t *testing.T) {
+	e := setupProject(t)
+	out := e.callTool("dexter_rename_symbol", map[string]any{
+		"module": "MyApp.Accounts", "new_name": "MyApp.Users",
+	})
+	wantContains(t, out,
+		"Rename module MyApp.Accounts to MyApp.Users",
+		"RENAME lib/my_app/accounts.ex → lib/my_app/users.ex",
+		"RENAME lib/my_app/accounts/creator.ex → lib/my_app/users/creator.ex",
+		"-defmodule MyApp.Accounts do",
+		"+defmodule MyApp.Users do",
+		"-defmodule MyApp.Accounts.Creator do",
+		"+defmodule MyApp.Users.Creator do",
+		// Diffs for moved files are addressed at the new path.
+		"--- a/lib/my_app/users.ex",
+	)
+}
+
+func TestRenameTool_DoesNotModifyDisk(t *testing.T) {
+	e := setupProject(t)
+	before := hashTree(t, e.root)
+
+	e.callTool("dexter_rename_symbol", map[string]any{
+		"module": "MyApp.Accounts", "function": "fetch_user", "new_name": "get_user",
+	})
+	e.callTool("dexter_rename_symbol", map[string]any{
+		"module": "MyApp.Accounts", "new_name": "MyApp.Users",
+	})
+
+	after := hashTree(t, e.root)
+	if len(before) != len(after) {
+		t.Fatalf("file count changed: %d -> %d", len(before), len(after))
+	}
+	for path, h := range before {
+		if after[path] != h {
+			t.Errorf("file modified by rename tool: %s", path)
+		}
+	}
+}
+
+func TestRenameTool_Errors(t *testing.T) {
+	e := setupProject(t)
+
+	errText := e.callToolExpectError("dexter_rename_symbol", map[string]any{
+		"module": "MyApp.Accounts", "function": "fetch_user", "new_name": "NotValid",
+	})
+	wantContains(t, errText, "invalid function name")
+
+	errText = e.callToolExpectError("dexter_rename_symbol", map[string]any{
+		"module": "MyApp.Accounts", "function": "fetch_user", "new_name": "list_users",
+	})
+	wantContains(t, errText, "already exists")
+
+	errText = e.callToolExpectError("dexter_rename_symbol", map[string]any{
+		"module": "MyApp.Missing", "new_name": "MyApp.New",
+	})
+	wantContains(t, errText, "not found")
+}


### PR DESCRIPTION
Stacked on #84 (this PR's base is its `feat/mcp-server` branch and it merges after it).

## What

Adds `dexter_rename_symbol`: workspace-wide rename of a module or function over MCP, returned as a unified diff plus a list of file renames. **Nothing is written.** The agent applies the diff, performs the listed file moves (module renames follow the file naming convention, including submodule cascades), then calls `dexter_reindex`.

## Why the refactor

The existing rename machinery writes to disk while it collects edits (closed files are written directly; only open buffers come back as TextEdits). A "return a diff, don't write" tool cannot be built on that, so this PR splits rename into plan and apply:

- Site collection and defdelegate `as:`-span computation moved **verbatim** from `server.go` to `renameplan.go` (`git diff` shows the block deletion; the logic is unchanged).
- `FunctionRenamePlan` / `ModuleRenamePlan` compute the full new content of every affected file, plus conventional new paths for moved files, without touching disk.
- The LSP apply path (`renameFunctionEdits`, `moduleRename`) is unchanged in behavior and consumes the same shared pieces.

## Correctness

- `TestFunctionRenamePlan_MatchesApply` and `TestModuleRenamePlan_MatchesApply`: after computing a plan, the LSP apply path runs and every planned `NewText` must byte-match what landed on disk, and every changed file must be in the plan. This pins the two paths together permanently.
- All pre-existing rename tests pass unmodified.
- `TestRenameTool_DoesNotModifyDisk` hashes every file before/after tool calls.
- `internal/diff` (new, self-contained) is covered by golden tests, including the missing-trailing-newline cases (expected outputs were validated against `git apply` when written).

Manually exercised on a large codebase: a 30-file rename plan (62 call sites) computed in 52ms, working tree verified untouched.

