### PR TITLE
Let the editor move files a module rename renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Module rename left the old file behind** — renaming a module from the file that defines it moved that file on disk while the editor still held the buffer, so the next save recreated the old file with the new module name and the project no longer compiled (`cannot define module X because it is currently being defined in ...`). Open files are now moved by the editor, through a `rename` resource operation in the reply, and the server touches neither path
+- **Grouped aliases were not renamed** — `alias Old.{A, B}` (and the `require`/`import` forms) kept pointing at the old module after a module rename, and in open buffers the shared prefix was rewritten once per member (`Old` → `NewNewNew...`)
+
 ## [0.7.1] - 2026-06-12
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,6 +82,20 @@ Call sites are attributed to the **injecting module** in the store (not the defi
 
 `buildTextEdits` uses `findFunctionTokenColumns` to skip keyword-syntax occurrences (`resource_type: value`) — only `::` type separators pass through. Import-only sites use `findAllTokenColumns` since their keyword keys ARE function names.
 
+### Who moves a file
+
+A module rename also moves files whose names follow the module naming convention, and who performs the move depends on whether the editor holds the file:
+
+- **Closed files** — the server writes the new path and deletes the old one. This keeps large renames off the wire.
+- **Open files** — the client moves them, through a `rename` resource operation in the reply's `documentChanges`, ordered right after that file's own TextEdits so the edited buffer travels to the new path. The server touches neither path. Moving an open file server-side leaves the editor holding a modified buffer pointing at a deleted path, and the next save recreates the old file with the new module name — two files defining the same module.
+- **Open files, client without `resourceOperations: ["rename"]`** — the module is renamed in place and the file keeps its old name. Nothing is deleted underneath a live buffer.
+
+`protocol.WorkspaceEdit` from `go.lsp.dev/protocol` types `documentChanges` as `[]TextDocumentEdit` and cannot carry resource operations, so `internal/lsp/workspace_edit.go` defines the wire types and `renameHandler` answers `textDocument/rename` ahead of the generated dispatcher. A client that understands `documentChanges` ignores `changes` entirely, so once one file moves, every edit in the reply goes through `documentChanges`.
+
+### Grouped aliases
+
+`alias Old.{A, B}` (and the `require`/`import` forms) names the module once, as the prefix, while the index records one reference per member — so a member's full name never appears on the line. `findGroupedAliasEdits` handles both directions: renaming the prefix rewrites the prefix, renaming a member rewrites that member inside the braces. Since every member on the line resolves to the same prefix edit, `applyEdits` drops TextEdits that overlap one already emitted for that line; the on-disk path rewrites the line as it goes and never sees the second match.
+
 ## Key design decisions
 
 - **Tokenizer instead of tree-sitter for indexing** — a hand-rolled tokenizer + walker replaced the original regex-based parser for both file indexing and runtime `__using__` parsing. The tokenizer handles heredocs, sigils, multi-line expressions, and comments as opaque tokens, eliminating fragile line-joining heuristics. Tree-sitter is only used for scope-aware variable operations in files already opened by the editor.

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -65,6 +65,43 @@ func findFunctionTokenColumns(lineText, token string) []int {
 	return result
 }
 
+// findGroupedAlias locates a grouped alias/require/import of the form
+// `prefix.{A, B}` in lineText. It returns the column where prefix starts and
+// the span of the text between the braces, or -1 when the line holds no such
+// group for prefix.
+//
+// findAllTokenColumns cannot be used for this: the match would end at '{',
+// whose following character is an identifier char, so the boundary check
+// would reject every group.
+func findGroupedAlias(lineText, prefix string) (prefixCol, groupStart, groupEnd int) {
+	needle := prefix + ".{"
+	start := 0
+	for {
+		idx := strings.Index(lineText[start:], needle)
+		if idx < 0 {
+			return -1, -1, -1
+		}
+		abs := start + idx
+		// Only the leading boundary matters — the trailing one is the brace.
+		if abs > 0 {
+			if r, _ := utf8.DecodeLastRuneInString(lineText[:abs]); r != utf8.RuneError && isRenameIdentChar(r) {
+				start = abs + 1
+				continue
+			}
+		}
+		open := abs + len(needle)
+		end := strings.IndexByte(lineText[open:], '}')
+		if end < 0 {
+			// Multi-line group: the members continue on following lines, so
+			// take the rest of this one.
+			end = len(lineText)
+		} else {
+			end = open + end
+		}
+		return abs, open, end
+	}
+}
+
 // isTokenBoundary returns true when the substring [pos, pos+length) in s is
 // not immediately preceded or followed by an identifier character.
 func isTokenBoundary(s string, pos, length int) bool {

--- a/internal/lsp/rename_test.go
+++ b/internal/lsp/rename_test.go
@@ -2,11 +2,14 @@ package lsp
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
+	"go.lsp.dev/jsonrpc2"
 	"go.lsp.dev/protocol"
 	"go.lsp.dev/uri"
 )
@@ -323,9 +326,9 @@ func TestIsValidModuleName(t *testing.T) {
 
 // === Integration helpers ===
 
-func renameAt(t *testing.T, server *Server, docURI string, line, col uint32, newName string) *protocol.WorkspaceEdit {
+func renameAt(t *testing.T, server *Server, docURI string, line, col uint32, newName string) *WorkspaceEdit {
 	t.Helper()
-	result, err := server.Rename(context.Background(), &protocol.RenameParams{
+	result, err := server.RenameEdit(context.Background(), &protocol.RenameParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI(docURI)},
 			Position:     protocol.Position{Line: line, Character: col},
@@ -352,12 +355,34 @@ func prepareRenameAt(t *testing.T, server *Server, docURI string, line, col uint
 	return result
 }
 
-func collectEdits(edit *protocol.WorkspaceEdit, filePath string) []protocol.TextEdit {
+func collectEdits(edit *WorkspaceEdit, filePath string) []protocol.TextEdit {
 	if edit == nil {
 		return nil
 	}
 	fileURI := protocol.DocumentURI(uri.File(filePath))
-	return edit.Changes[fileURI]
+	if edits, ok := edit.Changes[fileURI]; ok {
+		return edits
+	}
+	for _, change := range edit.DocumentChanges {
+		if tde, ok := change.(TextDocumentEdit); ok && tde.TextDocument.URI == fileURI {
+			return tde.Edits
+		}
+	}
+	return nil
+}
+
+// renameOp returns the rename operation for filePath in the edit, if any.
+func renameOp(edit *WorkspaceEdit, filePath string) *RenameFile {
+	if edit == nil {
+		return nil
+	}
+	oldURI := protocol.DocumentURI(uri.File(filePath))
+	for _, change := range edit.DocumentChanges {
+		if rf, ok := change.(RenameFile); ok && rf.OldURI == oldURI {
+			return &rf
+		}
+	}
+	return nil
 }
 
 func hasEdit(edits []protocol.TextEdit, newText string) bool {
@@ -378,6 +403,50 @@ func editsContainLine(edits []protocol.TextEdit, lineNum uint32) bool {
 	return false
 }
 
+// expectClientRename asserts the edit asks the client to move oldPath to
+// newPath, and that the server left both paths alone: the editor owns an open
+// buffer, so it must perform the move itself.
+func expectClientRename(t *testing.T, edit *WorkspaceEdit, oldPath, newPath string) {
+	t.Helper()
+	op := renameOp(edit, oldPath)
+	if op == nil {
+		t.Fatalf("expected a rename operation for %s, got %+v", oldPath, edit)
+	}
+	if want := protocol.DocumentURI(uri.File(newPath)); op.NewURI != want {
+		t.Errorf("rename target = %s, want %s", op.NewURI, want)
+	}
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Errorf("server removed %s — the client has it open and must move it itself", oldPath)
+	}
+	if _, err := os.Stat(newPath); err == nil {
+		t.Errorf("server created %s — the client performs the move", newPath)
+	}
+}
+
+// bufferAfterEdits returns what content becomes once the edit's text edits for
+// filePath are applied, i.e. what the editor's buffer ends up holding.
+func bufferAfterEdits(t *testing.T, edit *WorkspaceEdit, filePath, content string) string {
+	t.Helper()
+	edits := collectEdits(edit, filePath)
+	sorted := make([]protocol.TextEdit, len(edits))
+	copy(sorted, edits)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Range.Start.Line != sorted[j].Range.Start.Line {
+			return sorted[i].Range.Start.Line > sorted[j].Range.Start.Line
+		}
+		return sorted[i].Range.Start.Character > sorted[j].Range.Start.Character
+	})
+	lines := strings.Split(content, "\n")
+	for _, e := range sorted {
+		l := int(e.Range.Start.Line)
+		if l >= len(lines) || e.Range.End.Line != e.Range.Start.Line {
+			t.Fatalf("unexpected edit range %+v", e.Range)
+		}
+		lines[l] = lines[l][:e.Range.Start.Character] + e.NewText + lines[l][e.Range.End.Character:]
+	}
+	return strings.Join(lines, "\n")
+}
+
 // fileContains checks whether the file at path contains the given substring.
 // Used to verify server-side writes for files not open in the editor.
 func fileContains(filePath, substr string) bool {
@@ -390,7 +459,7 @@ func fileContains(filePath, substr string) bool {
 
 // hasRename returns true if the rename result (either in WorkspaceEdit or
 // written directly to disk) contains newText for the given file.
-func hasRename(edit *protocol.WorkspaceEdit, filePath, newText string) bool {
+func hasRename(edit *WorkspaceEdit, filePath, newText string) bool {
 	if hasEdit(collectEdits(edit, filePath), newText) {
 		return true
 	}
@@ -1490,16 +1559,12 @@ end
 		t.Fatal("expected non-nil edit")
 	}
 
-	// File should have been written to new path and old path removed
+	// The file is open, so the edit must ask the client to move it and the
+	// server must not touch either path.
 	newPath := filepath.Join(server.projectRoot, "lib", "auth.ex")
-	if _, err := os.Stat(newPath); os.IsNotExist(err) {
-		t.Error("expected new file auth.ex to exist")
-	}
-	if _, err := os.Stat(oldPath); err == nil {
-		t.Error("expected old file accounts.ex to be removed")
-	}
-	if !fileContains(newPath, "defmodule MyApp.Auth") {
-		t.Errorf("expected new file to contain 'defmodule MyApp.Auth'")
+	expectClientRename(t, edit, oldPath, newPath)
+	if got := bufferAfterEdits(t, edit, oldPath, content); !strings.Contains(got, "defmodule MyApp.Auth") {
+		t.Errorf("expected buffer to contain 'defmodule MyApp.Auth', got:\n%s", got)
 	}
 }
 
@@ -1517,15 +1582,13 @@ end
 	defURI := "file://" + oldPath
 	server.docs.Set(defURI, content)
 
-	renameAt(t, server, defURI, 0, 20, "AuthTest")
+	edit := renameAt(t, server, defURI, 0, 20, "AuthTest")
 
 	// File should be renamed preserving the .exs extension
 	newPath := filepath.Join(server.projectRoot, "test", "auth_test.exs")
-	if _, err := os.Stat(newPath); os.IsNotExist(err) {
-		t.Error("expected file renamed to auth_test.exs (preserving .exs extension)")
-	}
-	if !fileContains(newPath, "defmodule MyApp.AuthTest") {
-		t.Errorf("expected 'defmodule MyApp.AuthTest' in new file")
+	expectClientRename(t, edit, oldPath, newPath)
+	if got := bufferAfterEdits(t, edit, oldPath, content); !strings.Contains(got, "defmodule MyApp.AuthTest") {
+		t.Errorf("expected buffer to contain 'defmodule MyApp.AuthTest', got:\n%s", got)
 	}
 }
 
@@ -1550,26 +1613,23 @@ end
 	indexFile(t, server.store, server.projectRoot, "lib/docusign.ex", defContent)
 	indexFile(t, server.store, server.projectRoot, "lib/web.ex", callerContent)
 
-	// Test 1: rename from the def file (open)
+	// Test 1: rename from the def file (open — the client moves it)
 	t.Run("from def file", func(t *testing.T) {
 		defURI := "file://" + oldPath
 		server.docs.Set(defURI, defContent)
 
-		renameAt(t, server, defURI, 0, 16, "Docusigns")
+		edit := renameAt(t, server, defURI, 0, 16, "Docusigns")
 
 		newPath := filepath.Join(server.projectRoot, "lib", "docusigns.ex")
-		if _, err := os.Stat(newPath); os.IsNotExist(err) {
-			t.Error("expected file renamed to docusigns.ex")
-		}
-		if !fileContains(newPath, "defmodule MyApp.Docusigns") {
-			data, _ := os.ReadFile(newPath)
-			t.Errorf("expected 'defmodule MyApp.Docusigns', got:\n%s", string(data))
+		expectClientRename(t, edit, oldPath, newPath)
+		if got := bufferAfterEdits(t, edit, oldPath, defContent); !strings.Contains(got, "defmodule MyApp.Docusigns") {
+			t.Errorf("expected 'defmodule MyApp.Docusigns', got:\n%s", got)
 		}
 	})
 
-	// Clean up test 1's renamed file and re-index with original content for test 2
-	_ = os.Remove(filepath.Join(server.projectRoot, "lib", "docusigns.ex"))
-	_ = server.store.RemoveFile(filepath.Join(server.projectRoot, "lib", "docusigns.ex"))
+	// Re-index with original content for test 2, and close the def file so it
+	// takes the closed-file path (moved on disk by the server)
+	server.docs.Close("file://" + oldPath)
 	indexFile(t, server.store, server.projectRoot, "lib/docusign.ex", defContent)
 
 	// Test 2: rename from a caller file via alias (def file is closed)
@@ -1831,12 +1891,10 @@ end
 end
 `)
 
-	renameAt(t, server, defURI, 0, 16, "Enterprises")
+	edit := renameAt(t, server, defURI, 0, 16, "Enterprises")
 
-	// Root file should be renamed
-	if _, err := os.Stat(filepath.Join(server.projectRoot, "lib", "enterprises.ex")); os.IsNotExist(err) {
-		t.Error("expected root module file renamed to enterprises.ex")
-	}
+	// Root file is open — the client renames it
+	expectClientRename(t, edit, defPath, filepath.Join(server.projectRoot, "lib", "enterprises.ex"))
 
 	// Submodule file is closed — should be moved to new directory on disk
 	newSubPath := filepath.Join(server.projectRoot, "lib", "enterprises", "do_something.ex")
@@ -1938,16 +1996,14 @@ end
 		t.Errorf("expected last segment range starting at col 16, got %d", r.Start.Character)
 	}
 
-	renameAt(t, server, defURI, 0, 16, "CostCalculatorZ")
+	edit := renameAt(t, server, defURI, 0, 16, "CostCalculatorZ")
 
-	// Check the renamed file has the full qualified name
+	// The open file moves via the client, and its buffer gets the full
+	// qualified name
 	newPath := filepath.Join(server.projectRoot, "lib", "cost_calculator_z.ex")
-	newContent, err := os.ReadFile(newPath)
-	if err != nil {
-		t.Fatalf("cannot read new file: %v", err)
-	}
-	if !strings.Contains(string(newContent), "defmodule MyApp.CostCalculatorZ do") {
-		t.Errorf("expected 'defmodule MyApp.CostCalculatorZ do', got:\n%s", newContent)
+	expectClientRename(t, edit, defPath, newPath)
+	if got := bufferAfterEdits(t, edit, defPath, content); !strings.Contains(got, "defmodule MyApp.CostCalculatorZ do") {
+		t.Errorf("expected 'defmodule MyApp.CostCalculatorZ do', got:\n%s", got)
 	}
 }
 
@@ -2774,5 +2830,367 @@ end
 	}
 	if !hasCorrectEdit {
 		t.Errorf("expected edit containing 'Approvals' in child file, got: %v", childEdits)
+	}
+}
+
+// Regression: renaming a module from the file that defines it used to move
+// that file on disk while the editor still held the buffer, and hand the
+// editor TextEdits for the now-deleted path. Neovim applied the edits to the
+// stale buffer, and the next save (`:w`, `:wa`, format-on-save) recreated the
+// old file holding the new module name — two files defining the same module,
+// and the project stopped compiling.
+func TestRename_Module_OpenFileMovedByClientNotServer(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	content := `defmodule MyApp.Accounts do
+  def list_users, do: []
+end
+`
+	oldPath := filepath.Join(server.projectRoot, "lib", "accounts.ex")
+	newPath := filepath.Join(server.projectRoot, "lib", "auth.ex")
+	indexFile(t, server.store, server.projectRoot, "lib/accounts.ex", content)
+	defURI := "file://" + oldPath
+	server.docs.Set(defURI, content)
+
+	edit := renameAt(t, server, defURI, 0, 20, "Auth")
+	if edit == nil {
+		t.Fatal("expected non-nil edit")
+	}
+
+	// The server must not touch a file the editor has open.
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Error("server deleted accounts.ex while the editor had it open")
+	}
+	if _, err := os.Stat(newPath); err == nil {
+		t.Error("server created auth.ex; the client performs the move")
+	}
+
+	// A client that applies documentChanges ignores changes entirely, so
+	// nothing may be left there.
+	if len(edit.Changes) != 0 {
+		t.Errorf("changes must be empty when documentChanges is used, got %v", edit.Changes)
+	}
+
+	// The buffer's edits must come before its rename operation, so the edited
+	// buffer travels to the new path.
+	oldURI := protocol.DocumentURI(uri.File(oldPath))
+	editIdx, renameIdx := -1, -1
+	for i, change := range edit.DocumentChanges {
+		switch c := change.(type) {
+		case TextDocumentEdit:
+			if c.TextDocument.URI == oldURI {
+				editIdx = i
+			}
+		case RenameFile:
+			if c.OldURI == oldURI {
+				renameIdx = i
+			}
+		}
+	}
+	if editIdx < 0 {
+		t.Fatalf("expected text edits for %s, got %+v", oldPath, edit.DocumentChanges)
+	}
+	if renameIdx < 0 {
+		t.Fatalf("expected a rename operation for %s, got %+v", oldPath, edit.DocumentChanges)
+	}
+	if editIdx > renameIdx {
+		t.Error("text edits must precede the rename operation for the same file")
+	}
+	if got := bufferAfterEdits(t, edit, oldPath, content); !strings.Contains(got, "defmodule MyApp.Auth") {
+		t.Errorf("expected the buffer to become 'defmodule MyApp.Auth', got:\n%s", got)
+	}
+}
+
+// A client that cannot apply rename operations gets the module renamed in
+// place. The file keeps its old name, but nothing is deleted underneath an
+// open buffer, so no save can resurrect a duplicate module.
+func TestRename_Module_OpenFileLeftInPlaceWithoutRenameOps(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+	server.renameFileOpsSupported = false
+
+	content := `defmodule MyApp.Accounts do
+  def list_users, do: []
+end
+`
+	oldPath := filepath.Join(server.projectRoot, "lib", "accounts.ex")
+	newPath := filepath.Join(server.projectRoot, "lib", "auth.ex")
+	indexFile(t, server.store, server.projectRoot, "lib/accounts.ex", content)
+	defURI := "file://" + oldPath
+	server.docs.Set(defURI, content)
+
+	edit := renameAt(t, server, defURI, 0, 20, "Auth")
+
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Error("expected accounts.ex to stay in place")
+	}
+	if _, err := os.Stat(newPath); err == nil {
+		t.Error("expected no auth.ex — the file cannot move while the client holds it")
+	}
+	if len(edit.DocumentChanges) != 0 {
+		t.Errorf("expected no resource operations, got %+v", edit.DocumentChanges)
+	}
+	if got := bufferAfterEdits(t, edit, oldPath, content); !strings.Contains(got, "defmodule MyApp.Auth") {
+		t.Errorf("expected the buffer to become 'defmodule MyApp.Auth', got:\n%s", got)
+	}
+}
+
+// The wire format is what the editor actually acts on, and a wrong JSON tag
+// would be invisible to every other test here.
+func TestWorkspaceEdit_RenameOperationJSON(t *testing.T) {
+	edit := &WorkspaceEdit{
+		DocumentChanges: []interface{}{
+			textDocumentEdit(protocol.DocumentURI("file:///p/lib/accounts.ex"), []protocol.TextEdit{{
+				Range:   protocol.Range{Start: protocol.Position{Line: 0, Character: 16}, End: protocol.Position{Line: 0, Character: 24}},
+				NewText: "Auth",
+			}}),
+			newRenameFile("/p/lib/accounts.ex", "/p/lib/auth.ex"),
+		},
+	}
+
+	data, err := json.Marshal(edit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Changes         map[string]interface{} `json:"changes"`
+		DocumentChanges []struct {
+			Kind         string `json:"kind"`
+			OldURI       string `json:"oldUri"`
+			NewURI       string `json:"newUri"`
+			TextDocument *struct {
+				URI     string      `json:"uri"`
+				Version interface{} `json:"version"`
+			} `json:"textDocument"`
+			Edits   []protocol.TextEdit `json:"edits"`
+			Options *struct {
+				Overwrite bool `json:"overwrite"`
+			} `json:"options"`
+		} `json:"documentChanges"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Changes != nil {
+		t.Errorf("changes must be omitted, got %v", got.Changes)
+	}
+	if len(got.DocumentChanges) != 2 {
+		t.Fatalf("expected 2 documentChanges, got %s", data)
+	}
+	first := got.DocumentChanges[0]
+	if first.TextDocument == nil || first.TextDocument.URI != "file:///p/lib/accounts.ex" {
+		t.Errorf("first change should be a text document edit, got %s", data)
+	}
+	if first.TextDocument != nil && first.TextDocument.Version != nil {
+		t.Errorf("version must be null, got %v", first.TextDocument.Version)
+	}
+	if len(first.Edits) != 1 {
+		t.Errorf("expected the text edit to survive, got %s", data)
+	}
+	second := got.DocumentChanges[1]
+	if second.Kind != "rename" {
+		t.Errorf("kind = %q, want \"rename\"", second.Kind)
+	}
+	if second.OldURI != "file:///p/lib/accounts.ex" || second.NewURI != "file:///p/lib/auth.ex" {
+		t.Errorf("rename URIs = %s → %s", second.OldURI, second.NewURI)
+	}
+	if second.Options == nil || !second.Options.Overwrite {
+		t.Errorf("expected overwrite:true, got %s", data)
+	}
+}
+
+// The rename request must be answered by our own handler: the generated
+// dispatcher marshals a protocol.WorkspaceEdit, which has nowhere to put
+// resource operations, so a mis-wired handler would silently drop every file
+// move.
+func TestRenameHandler_RepliesWithResourceOperations(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	content := `defmodule MyApp.Accounts do
+  def list_users, do: []
+end
+`
+	oldPath := filepath.Join(server.projectRoot, "lib", "accounts.ex")
+	indexFile(t, server.store, server.projectRoot, "lib/accounts.ex", content)
+	defURI := "file://" + oldPath
+	server.docs.Set(defURI, content)
+
+	call, err := jsonrpc2.NewCall(jsonrpc2.NewNumberID(1), protocol.MethodTextDocumentRename, &protocol.RenameParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI(defURI)},
+			Position:     protocol.Position{Line: 0, Character: 20},
+		},
+		NewName: "Auth",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var replied interface{}
+	nextCalled := false
+	handler := server.renameHandler(func(context.Context, jsonrpc2.Replier, jsonrpc2.Request) error {
+		nextCalled = true
+		return nil
+	})
+	err = handler(context.Background(), func(_ context.Context, result interface{}, err error) error {
+		replied = result
+		return err
+	}, call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nextCalled {
+		t.Error("rename must not fall through to the generated dispatcher")
+	}
+
+	edit, ok := replied.(*WorkspaceEdit)
+	if !ok {
+		t.Fatalf("replied with %T, want *WorkspaceEdit", replied)
+	}
+	if renameOp(edit, oldPath) == nil {
+		t.Errorf("reply carries no rename operation: %+v", edit.DocumentChanges)
+	}
+}
+
+// Regression: `alias Old.{A, B}` names the module once, as the prefix before
+// the brace, while the index records one reference per member. Matching a
+// member's full name against the line found nothing, so grouped aliases kept
+// pointing at the old module and the project stopped compiling.
+func TestRename_Module_GroupedAlias(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	indexFile(t, server.store, server.projectRoot, "lib/shared_lib.ex", `defmodule SharedLib do
+  def start, do: :ok
+end
+`)
+	indexFile(t, server.store, server.projectRoot, "lib/shared_lib/worker.ex", `defmodule SharedLib.Worker do
+  def call, do: :ok
+end
+`)
+	indexFile(t, server.store, server.projectRoot, "lib/shared_lib/config.ex", `defmodule SharedLib.Config do
+  def get, do: :ok
+end
+`)
+	callerContent := `defmodule MyApp.Runner do
+  alias SharedLib.{Config, Worker}
+  require SharedLib.{Config, Worker}
+
+  def run do
+    Config.get()
+    Worker.call()
+  end
+end
+`
+	callerPath := filepath.Join(server.projectRoot, "lib", "runner.ex")
+	indexFile(t, server.store, server.projectRoot, "lib/runner.ex", callerContent)
+
+	defPath := filepath.Join(server.projectRoot, "lib", "shared_lib.ex")
+	defURI := "file://" + defPath
+	server.docs.Set(defURI, `defmodule SharedLib do
+  def start, do: :ok
+end
+`)
+
+	renameAt(t, server, defURI, 0, 10, "CoreLib")
+
+	// The caller is closed, so the server rewrites it on disk
+	got, err := os.ReadFile(callerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"alias CoreLib.{Config, Worker}", "require CoreLib.{Config, Worker}"} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("expected %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(string(got), "SharedLib") {
+		t.Errorf("SharedLib should be gone, got:\n%s", got)
+	}
+}
+
+// Renaming a member of a grouped alias rewrites the member, not the prefix.
+func TestRename_Module_GroupedAliasMemberRenamed(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	indexFile(t, server.store, server.projectRoot, "lib/shared_lib/worker.ex", `defmodule SharedLib.Worker do
+  def call, do: :ok
+end
+`)
+	indexFile(t, server.store, server.projectRoot, "lib/shared_lib/config.ex", `defmodule SharedLib.Config do
+  def get, do: :ok
+end
+`)
+	callerContent := `defmodule MyApp.Runner do
+  alias SharedLib.{Config, Worker}
+
+  def run, do: Worker.call()
+end
+`
+	callerPath := filepath.Join(server.projectRoot, "lib", "runner.ex")
+	indexFile(t, server.store, server.projectRoot, "lib/runner.ex", callerContent)
+
+	defPath := filepath.Join(server.projectRoot, "lib", "shared_lib", "worker.ex")
+	defURI := "file://" + defPath
+	server.docs.Set(defURI, `defmodule SharedLib.Worker do
+  def call, do: :ok
+end
+`)
+
+	renameAt(t, server, defURI, 0, 20, "Job")
+
+	got, err := os.ReadFile(callerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "alias SharedLib.{Config, Job}") {
+		t.Errorf("expected 'alias SharedLib.{Config, Job}', got:\n%s", got)
+	}
+}
+
+// Regression: every member of `alias Old.{A, B, C}` is its own indexed
+// reference, but they share one edit to the prefix. TextEdits are all relative
+// to the original buffer, so emitting the same span once per member made the
+// editor apply the replacement repeatedly (Old → NewNewNew...).
+func TestRename_Module_GroupedAliasInOpenBufferEditedOnce(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	indexFile(t, server.store, server.projectRoot, "lib/shared_lib.ex", `defmodule SharedLib do
+  def start, do: :ok
+end
+`)
+	for _, sub := range []string{"Config", "Worker", "Job"} {
+		indexFile(t, server.store, server.projectRoot,
+			"lib/shared_lib/"+strings.ToLower(sub)+".ex",
+			"defmodule SharedLib."+sub+" do\n  def call, do: :ok\nend\n")
+	}
+
+	callerContent := `defmodule MyApp.Runner do
+  alias SharedLib.{Config, Job, Worker}
+
+  def run, do: {Config.call(), Job.call(), Worker.call()}
+end
+`
+	callerPath := filepath.Join(server.projectRoot, "lib", "runner.ex")
+	indexFile(t, server.store, server.projectRoot, "lib/runner.ex", callerContent)
+	callerURI := "file://" + callerPath
+	server.docs.Set(callerURI, callerContent)
+
+	defPath := filepath.Join(server.projectRoot, "lib", "shared_lib.ex")
+	defURI := "file://" + defPath
+	server.docs.Set(defURI, `defmodule SharedLib do
+  def start, do: :ok
+end
+`)
+
+	edit := renameAt(t, server, defURI, 0, 10, "CoreLib")
+
+	got := bufferAfterEdits(t, edit, callerPath, callerContent)
+	if !strings.Contains(got, "alias CoreLib.{Config, Job, Worker}") {
+		t.Errorf("expected 'alias CoreLib.{Config, Job, Worker}', got:\n%s", got)
 	}
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -92,9 +93,10 @@ type Server struct {
 	depsCache   map[string]bool // dir → whether files in that dir are deps
 	depsCacheMu sync.RWMutex
 
-	conn                  jsonrpc2.Conn // raw connection for server-initiated requests not on the Client interface
-	showDocumentSupported bool          // client supports window/showDocument (LSP 3.16+)
-	snippetSupport        bool          // client supports snippet insert text in completions
+	conn                   jsonrpc2.Conn // raw connection for server-initiated requests not on the Client interface
+	showDocumentSupported  bool          // client supports window/showDocument (LSP 3.16+)
+	renameFileOpsSupported bool          // client applies rename resource operations in a WorkspaceEdit
+	snippetSupport         bool          // client supports snippet insert text in completions
 
 	reindexing          sync.Mutex // serializes concurrent backgroundReindex calls
 	notifiedOTPMismatch sync.Once  // prevents repeated OTP mismatch warnings
@@ -146,7 +148,7 @@ func Serve(in io.Reader, out io.Writer, s *store.Store, projectRoot string) erro
 	server.client = protocol.ClientDispatcher(conn, logger)
 	server.conn = conn
 
-	handler := protocol.ServerHandler(server, nil)
+	handler := server.renameHandler(protocol.ServerHandler(server, nil))
 	ctx := context.Background()
 
 	conn.Go(ctx, handler)
@@ -402,6 +404,17 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 
 	if params.Capabilities.Window != nil && params.Capabilities.Window.ShowDocument != nil {
 		s.showDocumentSupported = params.Capabilities.Window.ShowDocument.Support
+	}
+	// Resource operations only exist inside documentChanges, so advertising
+	// them implies documentChanges support. Neovim, for one, lists
+	// resourceOperations without setting the separate documentChanges flag.
+	if ws := params.Capabilities.Workspace; ws != nil && ws.WorkspaceEdit != nil {
+		for _, op := range ws.WorkspaceEdit.ResourceOperations {
+			if op == "rename" {
+				s.renameFileOpsSupported = true
+				break
+			}
+		}
 	}
 	if params.Capabilities.TextDocument != nil && params.Capabilities.TextDocument.Completion != nil &&
 		params.Capabilities.TextDocument.Completion.CompletionItem != nil {
@@ -4082,7 +4095,17 @@ func (s *Server) References(ctx context.Context, params *protocol.ReferenceParam
 	return locations, nil
 }
 
+// Rename implements the protocol.Server interface. It exists only to satisfy
+// the generated dispatcher; Serve intercepts textDocument/rename before that
+// dispatcher runs so the reply can carry resource operations, which
+// protocol.WorkspaceEdit cannot express.
 func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*protocol.WorkspaceEdit, error) {
+	edit, err := s.RenameEdit(ctx, params)
+	return edit.toProtocol(), err
+}
+
+// RenameEdit computes the workspace edit for a textDocument/rename request.
+func (s *Server) RenameEdit(ctx context.Context, params *protocol.RenameParams) (*WorkspaceEdit, error) {
 	docURI := string(params.TextDocument.URI)
 	text, ok := s.docs.GetOrLoad(docURI)
 	if !ok {
@@ -4122,7 +4145,7 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 						NewText: params.NewName,
 					})
 				}
-				return &protocol.WorkspaceEdit{Changes: changes}, nil
+				return &WorkspaceEdit{Changes: changes}, nil
 			}
 		}
 	}
@@ -4159,7 +4182,7 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 						})
 					}
 				}
-				return &protocol.WorkspaceEdit{Changes: changes}, nil
+				return &WorkspaceEdit{Changes: changes}, nil
 			}
 		}
 
@@ -4193,7 +4216,7 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 				if !isValidModuleName(newModule) {
 					return nil, fmt.Errorf("invalid module name %q: must be CamelCase segments separated by dots", params.NewName)
 				}
-				return s.renameModuleEdits(ctx, fullModule, newModule, uriToPath(params.TextDocument.URI))
+				return s.renameModuleEdits(fullModule, newModule)
 			}
 		}
 	}
@@ -4203,7 +4226,7 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 
 // renameFunctionEdits builds a WorkspaceEdit renaming all occurrences of
 // module.functionName to newName across the codebase.
-func (s *Server) renameFunctionEdits(module, functionName, newName string) (*protocol.WorkspaceEdit, error) {
+func (s *Server) renameFunctionEdits(module, functionName, newName string) (*WorkspaceEdit, error) {
 	// Collect all (filePath, lineNumber) pairs — definitions + references
 	type siteKey struct {
 		filePath string
@@ -4399,8 +4422,9 @@ func (s *Server) renameFunctionEdits(module, functionName, newName string) (*pro
 // Files not currently open in the editor are written directly to disk in
 // parallel goroutines. Only open buffers are included in the returned
 // WorkspaceEdit, keeping the response small and avoiding editor freezes.
-// Files following the naming convention are also renamed/moved.
-func (s *Server) renameModuleEdits(ctx context.Context, oldModule, newModule, triggerFilePath string) (*protocol.WorkspaceEdit, error) {
+// Files following the naming convention are also renamed/moved: closed ones
+// by the server, open ones by the client through rename operations.
+func (s *Server) renameModuleEdits(oldModule, newModule string) (*WorkspaceEdit, error) {
 	mr := s.buildModuleRename(oldModule, newModule)
 
 	// Check for collisions: verify that none of the target module names
@@ -4414,36 +4438,56 @@ func (s *Server) renameModuleEdits(ctx context.Context, oldModule, newModule, tr
 
 	fileCache := mr.readFiles()
 
-	movedFiles, openMovedFiles, showDocumentPath := mr.moveConventionalFiles(fileCache, triggerFilePath)
+	movedFiles, clientRenames := mr.moveConventionalFiles(fileCache)
 	openChanges := mr.applyEdits(fileCache, movedFiles)
-	mr.reindex(fileCache, movedFiles, openMovedFiles)
+	mr.reindex(fileCache, movedFiles, clientRenames)
 
-	// For open files that were moved: send showDocument so the editor opens
-	// the new path, then delete the old file in the background.
-	if s.showDocumentSupported && s.conn != nil {
-		for oldPath, newPath := range openMovedFiles {
-			showURI := protocol.URI(string(uri.File(newPath)))
-			takeFocus := newPath == showDocumentPath
-			go func() {
-				var result protocol.ShowDocumentResult
-				_ = protocol.Call(context.Background(), s.conn, "window/showDocument", &protocol.ShowDocumentParams{
-					URI:       showURI,
-					TakeFocus: takeFocus,
-				}, &result)
-				// Delete old file after the editor has been redirected
-				_ = os.Remove(oldPath)
-				_ = s.store.RemoveFile(oldPath)
-			}()
+	if len(clientRenames) == 0 {
+		return &WorkspaceEdit{Changes: openChanges}, nil
+	}
+	return renamesToDocumentChanges(openChanges, clientRenames), nil
+}
+
+// renamesToDocumentChanges folds the open buffers' text edits and the file
+// moves the client must perform into a single ordered documentChanges list.
+//
+// Each renamed file's text edits come immediately before its rename
+// operation: the client edits the buffer in place and then moves it, so the
+// buffer follows the file and no stale copy is left behind to be saved back
+// over the rename. Text edits and moves cannot be split across `changes` and
+// `documentChanges` because a client that understands documentChanges ignores
+// `changes` entirely.
+func renamesToDocumentChanges(openChanges map[protocol.DocumentURI][]protocol.TextEdit, clientRenames map[string]string) *WorkspaceEdit {
+	renamedPaths := make([]string, 0, len(clientRenames))
+	for oldPath := range clientRenames {
+		renamedPaths = append(renamedPaths, oldPath)
+	}
+	sort.Strings(renamedPaths)
+
+	changes := make([]interface{}, 0, len(openChanges)+len(clientRenames))
+	renamedURIs := make(map[protocol.DocumentURI]bool, len(clientRenames))
+	for _, oldPath := range renamedPaths {
+		oldURI := pathToURI(oldPath)
+		renamedURIs[oldURI] = true
+		if edits := openChanges[oldURI]; len(edits) > 0 {
+			changes = append(changes, textDocumentEdit(oldURI, edits))
 		}
-	} else if len(openMovedFiles) > 0 {
-		// Client doesn't support showDocument — still clean up old files
-		for oldPath := range openMovedFiles {
-			_ = os.Remove(oldPath)
-			_ = s.store.RemoveFile(oldPath)
-		}
+		changes = append(changes, newRenameFile(oldPath, clientRenames[oldPath]))
 	}
 
-	return &protocol.WorkspaceEdit{Changes: openChanges}, nil
+	otherURIs := make([]string, 0, len(openChanges))
+	for fileURI := range openChanges {
+		if !renamedURIs[fileURI] {
+			otherURIs = append(otherURIs, string(fileURI))
+		}
+	}
+	sort.Strings(otherURIs)
+	for _, u := range otherURIs {
+		fileURI := protocol.DocumentURI(u)
+		changes = append(changes, textDocumentEdit(fileURI, openChanges[fileURI]))
+	}
+
+	return &WorkspaceEdit{DocumentChanges: changes}
 }
 
 // moduleRename holds the state for a module rename operation.
@@ -4620,6 +4664,9 @@ func (mr *moduleRename) findModuleEdits(lineText string, token string) []moduleE
 		}
 		return results
 	}
+	if results := mr.findGroupedAliasEdits(lineText, token, newToken); results != nil {
+		return results
+	}
 	oldSuffix := token
 	newSuffix := newToken
 	for {
@@ -4645,6 +4692,50 @@ func (mr *moduleRename) findModuleEdits(lineText string, token string) []moduleE
 		}
 	}
 	return nil
+}
+
+// findGroupedAliasEdits handles `alias Prefix.{A, B}` (and the require/import
+// forms), where the module name is written once as the prefix and each member
+// is indexed as its own reference — so the reference's full name never appears
+// on the line.
+//
+// Which half moves depends on the rename: renaming the prefix rewrites the
+// prefix, renaming a member rewrites that member inside the braces. Sites for
+// the other members on the same line find nothing once the prefix is rewritten,
+// so a group is only edited once.
+func (mr *moduleRename) findGroupedAliasEdits(lineText, token, newToken string) []moduleEditResult {
+	dot := strings.LastIndexByte(token, '.')
+	if dot <= 0 {
+		return nil
+	}
+	prefix, member := token[:dot], token[dot+1:]
+	prefixCol, groupStart, groupEnd := findGroupedAlias(lineText, prefix)
+	if prefixCol < 0 {
+		return nil
+	}
+	memberCols := findAllTokenColumns(lineText[groupStart:groupEnd], member)
+	if len(memberCols) == 0 {
+		return nil
+	}
+
+	newDot := strings.LastIndexByte(newToken, '.')
+	if newDot <= 0 {
+		// The member lost its namespace; a grouped alias cannot express that.
+		return nil
+	}
+	if newPrefix := newToken[:newDot]; newPrefix != prefix {
+		return []moduleEditResult{{prefixCol, len(prefix), newPrefix}}
+	}
+
+	newMember := newToken[newDot+1:]
+	if newMember == member {
+		return nil
+	}
+	results := make([]moduleEditResult, 0, len(memberCols))
+	for _, col := range memberCols {
+		results = append(results, moduleEditResult{groupStart + col, len(member), newMember})
+	}
+	return results
 }
 
 type moduleEditResult struct {
@@ -4703,14 +4794,21 @@ func (mr *moduleRename) conventionalNewPath(r store.LookupResult) (string, bool)
 	return filepath.Join(prefix, filepath.FromSlash(newSuffix)), true
 }
 
-// moveConventionalFiles moves files that follow the naming convention to their
-// new paths, applying edits in the process. Open files are NOT moved on disk —
-// they are left for applyEdits to handle via TextEdits so the editor buffer
-// stays in sync. Returns moved files, paths that need showDocument calls
-// (open files that were moved), and the path to show for the trigger file.
-func (mr *moduleRename) moveConventionalFiles(fileCache map[string]moduleFileInfo, triggerFilePath string) (movedFiles map[string]string, openMovedFiles map[string]string, showDocumentPath string) {
+// moveConventionalFiles moves files that follow the naming convention to
+// their new paths, applying edits in the process.
+//
+// Files open in the editor are NOT moved here when the client can apply
+// rename resource operations: the client owns the buffer, so it must move the
+// file itself (see renamesToDocumentChanges). Moving it behind the client's
+// back leaves the editor with a modified buffer pointing at a deleted path,
+// and saving that buffer recreates the old file with the new module name.
+//
+// Returns the files moved on disk, the moves left to the client, the open
+// files moved on disk anyway (fallback clients, which need showDocument and a
+// deferred delete), and the path to show for the trigger file.
+func (mr *moduleRename) moveConventionalFiles(fileCache map[string]moduleFileInfo) (movedFiles, clientRenames map[string]string) {
 	movedFiles = make(map[string]string)
-	openMovedFiles = make(map[string]string)
+	clientRenames = make(map[string]string)
 	for _, r := range mr.allModuleDefs {
 		if _, ok := mr.moduleRenames[r.Module]; !ok {
 			continue
@@ -4724,26 +4822,21 @@ func (mr *moduleRename) moveConventionalFiles(fileCache map[string]moduleFileInf
 			continue
 		}
 
-		// Open files: write the new file to disk but DON'T delete the old one
-		// or mark it in movedFiles. Instead track it in openMovedFiles so that
-		// applyEdits still produces TextEdits for the editor buffer, and we
-		// send showDocument to redirect the editor to the new path.
 		if fi.open {
-			updatedLines := mr.applyEditsToLines(fi.lines, mr.sitesByFile[r.FilePath])
-			content := strings.Join(updatedLines, "\n")
-			if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
-				log.Printf("Rename: cannot create dir for %s: %v", newPath, err)
+			// Client applies rename operations: leave both paths untouched.
+			// applyEdits still emits TextEdits for the old URI, and the rename
+			// operation queued after them carries the edited buffer to the new
+			// path.
+			if mr.server.renameFileOpsSupported {
+				mr.server.debugf("Rename: %s → %s (client-applied)", r.FilePath, newPath)
+				clientRenames[r.FilePath] = newPath
 				continue
 			}
-			if err := os.WriteFile(newPath, []byte(content), 0644); err != nil {
-				log.Printf("Rename: cannot write %s: %v", newPath, err)
-				continue
-			}
-			mr.server.debugf("Rename: %s → %s (open, deferred delete)", r.FilePath, newPath)
-			openMovedFiles[r.FilePath] = newPath
-			if r.FilePath == triggerFilePath && showDocumentPath == "" {
-				showDocumentPath = newPath
-			}
+			// Client cannot move the file and we must not do it behind its
+			// back: deleting a path the editor still has open leaves a buffer
+			// that recreates the file on the next save. Rename the contents in
+			// place and leave the file where it is.
+			log.Printf("Rename: leaving %s in place — client cannot apply rename operations and the file is open", r.FilePath)
 			continue
 		}
 
@@ -4758,13 +4851,14 @@ func (mr *moduleRename) moveConventionalFiles(fileCache map[string]moduleFileInf
 			log.Printf("Rename: cannot write %s: %v", newPath, err)
 			continue
 		}
+
 		if err := os.Remove(r.FilePath); err != nil {
 			log.Printf("Rename: cannot remove %s: %v", r.FilePath, err)
 		}
 		mr.server.debugf("Rename: %s → %s", r.FilePath, newPath)
 		movedFiles[r.FilePath] = newPath
 	}
-	return movedFiles, openMovedFiles, showDocumentPath
+	return movedFiles, clientRenames
 }
 
 // applyEdits applies text edits to all non-moved files: open buffers get
@@ -4783,12 +4877,24 @@ func (mr *moduleRename) applyEdits(fileCache map[string]moduleFileInfo, movedFil
 		}
 		if fi.open {
 			fileURI := protocol.DocumentURI(uri.File(fp))
+			// Each site is matched against the original line, so two sites can
+			// resolve to the same span — `alias Old.{A, B}` is one reference
+			// per member but a single edit to the shared prefix. The on-disk
+			// path rewrites the line as it goes and never sees the second
+			// match; TextEdits are all relative to the original text, so
+			// overlapping ones have to be dropped here or the editor applies
+			// the replacement twice.
+			claimed := make(map[int][]moduleEditResult)
 			for _, es := range sites {
 				if es.line-1 >= len(fi.lines) {
 					continue
 				}
 				lineText := fi.lines[es.line-1]
 				for _, e := range mr.findModuleEdits(lineText, es.token) {
+					if overlapsClaimed(claimed[es.line], e) {
+						continue
+					}
+					claimed[es.line] = append(claimed[es.line], e)
 					openChanges[fileURI] = append(openChanges[fileURI], protocol.TextEdit{
 						Range: protocol.Range{
 							Start: protocol.Position{Line: uint32(es.line - 1), Character: uint32(e.col)},
@@ -4813,9 +4919,28 @@ func (mr *moduleRename) applyEdits(fileCache map[string]moduleFileInfo, movedFil
 	return openChanges
 }
 
+// overlapsClaimed reports whether e covers any column already taken by an
+// edit on the same line.
+func overlapsClaimed(claimed []moduleEditResult, e moduleEditResult) bool {
+	for _, c := range claimed {
+		if e.col < c.col+c.length && c.col < e.col+e.length {
+			return true
+		}
+	}
+	return false
+}
+
 // reindex re-parses all touched files asynchronously after the rename.
-func (mr *moduleRename) reindex(fileCache map[string]moduleFileInfo, movedFiles map[string]string, openMovedFiles map[string]string) {
+//
+// movedFiles were moved on disk by the server, so their new paths are read
+// back from disk. clientRenames have not moved yet — the client applies them
+// when it receives the reply — so their new paths are indexed from the text
+// the edits produce.
+func (mr *moduleRename) reindex(fileCache map[string]moduleFileInfo, movedFiles, clientRenames map[string]string) {
 	for oldPath := range movedFiles {
+		_ = mr.server.store.RemoveFile(oldPath)
+	}
+	for oldPath := range clientRenames {
 		_ = mr.server.store.RemoveFile(oldPath)
 	}
 
@@ -4839,8 +4964,8 @@ func (mr *moduleRename) reindex(fileCache map[string]moduleFileInfo, movedFiles 
 		}
 		updatedLines := mr.applyEditsToLines(fi.lines, mr.sitesByFile[fp])
 		updatedText := strings.Join(updatedLines, "\n")
-		if newPath, moved := openMovedFiles[fp]; moved {
-			// Open file that was moved: reindex at the new path
+		if newPath, moved := clientRenames[fp]; moved {
+			// Open file the client is about to move: index at the new path
 			openReindexes = append(openReindexes, textReindex{newPath, updatedText})
 		} else if fi.open {
 			openReindexes = append(openReindexes, textReindex{fp, updatedText})
@@ -4849,11 +4974,15 @@ func (mr *moduleRename) reindex(fileCache map[string]moduleFileInfo, movedFiles 
 		}
 	}
 
-	// Also reindex open moved files that had no edit sites (e.g. the file
+	// Also index client-renamed files that had no edit sites (e.g. the file
 	// only contained the defmodule line which is already in allModuleDefs)
-	for oldPath, newPath := range openMovedFiles {
-		if _, hasSites := mr.sitesByFile[oldPath]; !hasSites {
-			reindexPaths = append(reindexPaths, newPath)
+	for oldPath, newPath := range clientRenames {
+		if _, hasSites := mr.sitesByFile[oldPath]; hasSites {
+			continue
+		}
+		if fi, ok := fileCache[oldPath]; ok {
+			updatedLines := mr.applyEditsToLines(fi.lines, nil)
+			openReindexes = append(openReindexes, textReindex{newPath, strings.Join(updatedLines, "\n")})
 		}
 	}
 
@@ -4880,7 +5009,7 @@ type renameSite struct {
 // buildTextEdits creates a WorkspaceEdit replacing all whole-token occurrences
 // of oldToken with newToken. Open buffers are returned in the WorkspaceEdit;
 // closed files are written directly to disk in parallel goroutines.
-func (s *Server) buildTextEdits(sites []renameSite, oldToken, newToken string) *protocol.WorkspaceEdit {
+func (s *Server) buildTextEdits(sites []renameSite, oldToken, newToken string) *WorkspaceEdit {
 	// Group sites by file
 	sitesByFile := make(map[string][]renameSite, len(sites))
 	for _, site := range sites {
@@ -5012,7 +5141,7 @@ func (s *Server) buildTextEdits(sites []renameSite, oldToken, newToken string) *
 		}
 	}()
 
-	return &protocol.WorkspaceEdit{Changes: openChanges}
+	return &WorkspaceEdit{Changes: openChanges}
 }
 
 // reindexPaths re-parses and reindexes a specific set of files sequentially.

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -29,6 +29,9 @@ func setupTestServer(t *testing.T) (*Server, func()) {
 
 	server := NewServer(s, dir)
 	server.snippetSupport = true
+	// Match real editors (Neovim, VS Code, Helix, Zed): they all apply rename
+	// resource operations. Fallback behaviour has its own tests.
+	server.renameFileOpsSupported = true
 
 	// Resolve the mix binary so formatting tests work
 	if p, err := exec.LookPath("mix"); err == nil {

--- a/internal/lsp/workspace_edit.go
+++ b/internal/lsp/workspace_edit.go
@@ -1,0 +1,113 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"go.lsp.dev/jsonrpc2"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+)
+
+// WorkspaceEdit is our own workspace edit type. go.lsp.dev/protocol's
+// WorkspaceEdit types documentChanges as []TextDocumentEdit, so it cannot
+// express resource operations (create/rename/delete file). We need rename
+// operations: when a module rename moves a file that is open in the editor,
+// the editor itself must move the buffer, otherwise it is left holding a
+// modified buffer pointing at a path the server deleted — saving it recreates
+// the old file with the new module name and the project no longer compiles.
+//
+// Per the LSP spec a client that supports documentChanges must ignore
+// changes entirely when documentChanges is present, so the two fields are
+// mutually exclusive: emit everything through documentChanges as soon as one
+// resource operation is needed.
+type WorkspaceEdit struct {
+	Changes         map[protocol.DocumentURI][]protocol.TextEdit `json:"changes,omitempty"`
+	DocumentChanges []interface{}                                `json:"documentChanges,omitempty"`
+}
+
+// TextDocumentEdit is a documentChanges entry holding text edits for one
+// document. Version is always null: we never track buffer versions, and the
+// spec allows a null version to mean "apply without a version check".
+type TextDocumentEdit struct {
+	TextDocument versionedTextDocumentIdentifier `json:"textDocument"`
+	Edits        []protocol.TextEdit             `json:"edits"`
+}
+
+type versionedTextDocumentIdentifier struct {
+	URI     protocol.DocumentURI `json:"uri"`
+	Version *int                 `json:"version"`
+}
+
+// RenameFile is a documentChanges entry that moves a file. Clients apply
+// documentChanges in order, so a TextDocumentEdit for OldURI placed before
+// this operation is applied to the buffer first and then travels with it.
+type RenameFile struct {
+	Kind    string               `json:"kind"` // always "rename"
+	OldURI  protocol.DocumentURI `json:"oldUri"`
+	NewURI  protocol.DocumentURI `json:"newUri"`
+	Options *RenameFileOptions   `json:"options,omitempty"`
+}
+
+type RenameFileOptions struct {
+	Overwrite      bool `json:"overwrite,omitempty"`
+	IgnoreIfExists bool `json:"ignoreIfExists,omitempty"`
+}
+
+// pathToURI converts a filesystem path to a document URI.
+func pathToURI(path string) protocol.DocumentURI {
+	return protocol.DocumentURI(uri.File(path))
+}
+
+// newRenameFile builds a rename operation for the given paths.
+func newRenameFile(oldPath, newPath string) RenameFile {
+	return RenameFile{
+		Kind:    "rename",
+		OldURI:  pathToURI(oldPath),
+		NewURI:  pathToURI(newPath),
+		Options: &RenameFileOptions{Overwrite: true},
+	}
+}
+
+// textDocumentEdit builds a documentChanges entry for a single document.
+func textDocumentEdit(fileURI protocol.DocumentURI, edits []protocol.TextEdit) TextDocumentEdit {
+	return TextDocumentEdit{
+		TextDocument: versionedTextDocumentIdentifier{URI: fileURI},
+		Edits:        edits,
+	}
+}
+
+// toProtocol degrades a WorkspaceEdit to the protocol type, dropping resource
+// operations. Only used by the protocol.Server interface shim; the production
+// path replies with the full type through the handler in Serve.
+func (e *WorkspaceEdit) toProtocol() *protocol.WorkspaceEdit {
+	if e == nil {
+		return nil
+	}
+	return &protocol.WorkspaceEdit{Changes: e.Changes}
+}
+
+// renameHandler intercepts textDocument/rename so the reply can carry
+// resource operations. protocol.ServerHandler marshals whatever
+// Server.Rename returns, and protocol.WorkspaceEdit has no field for them,
+// so the request has to be answered before it reaches that dispatcher.
+func (s *Server) renameHandler(next jsonrpc2.Handler) jsonrpc2.Handler {
+	return func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		if req.Method() != protocol.MethodTextDocumentRename {
+			return next(ctx, reply, req)
+		}
+		var params protocol.RenameParams
+		if err := json.Unmarshal(req.Params(), &params); err != nil {
+			return reply(ctx, nil, fmt.Errorf("%w: %v", jsonrpc2.ErrParse, err))
+		}
+		edit, err := s.RenameEdit(ctx, &params)
+		if err != nil {
+			return reply(ctx, nil, err)
+		}
+		if edit == nil {
+			return reply(ctx, nil, nil)
+		}
+		return reply(ctx, edit, nil)
+	}
+}


### PR DESCRIPTION
Renaming a module from the file that defines it moved that file on disk while the editor still held the buffer, and handed the editor TextEdits for the path just deleted. Neovim applied them to the stale buffer, so the next save recreated the old file holding the new module name: two files defining the same module, and the project then couldn't compile due to duplicate modules.

Open files are now moved by the client, through a rename resource operation ordered right after that file's own TextEdits so the edited buffer travels to the new path; the server touches neither path. Closed files still move server-side, which is what keeps large renames off the wire. Clients without resourceOperations rename the module in place and leave the file where it is, so nothing is deleted under a live buffer.

go.lsp.dev/protocol types documentChanges as []TextDocumentEdit and cannot carry resource operations, so workspace_edit.go defines the wire types and renameHandler answers textDocument/rename ahead of the generated dispatcher.

Two other bugs also fixed:

- `alias Old.{A, B}` names the module once as the prefix while the index records one reference per member, so a member's full name never appears on the line and the group kept pointing at the old module.
- Every member on such a line resolves to the same prefix edit. TextEdits are relative to the original buffer, so emitting it once per member made the editor apply it repeatedly (Old -> NewNewNew...). Overlapping edits are now dropped; the on-disk path rewrites the line as it goes and never sees the second match.