### PR TITLE
Resolve atom-dispatched use chains across LSP features

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,25 @@ The `__using__` cache (`usingCacheEntry`) stores the parsed result of each modul
 - `using opts do` — ExUnit.CaseTemplate form (only when `use ExUnit.CaseTemplate` is present)
 - Function delegation — when the body calls a local helper like `using_block(opts)`, `parseHelperQuoteBlock` finds the function definition and parses its `quote do` body
 
+### Atom dispatch (`use MyAppWeb, :controller`)
+
+The Phoenix entrypoint form dispatches on an atom rather than injecting anything itself:
+
+```elixir
+defmacro __using__(which) when is_atom(which), do: apply(__MODULE__, which, [])
+def controller do
+  quote do ... end
+end
+```
+
+`usingDispatchParam` recognises this only when `apply/3` targets `__MODULE__` **and** dispatches on that clause's own parameter — a literal function name or another module is not atom dispatch. When it matches, `parseDispatchBodies` parses each `def name do quote do ... end end` in the file into its own `usingBody`, stored in `usingCacheEntry.dispatch` keyed by function name. Nothing is merged across targets.
+
+Selection happens at lookup time from the literal atom at the `use` site (`UseCall.Which`, or `UseCall.WhichKey` for the `use Mod, live_view: opts` form). `entry.bodyFor(which)` returns the matching body, or nil when the atom names no target — injecting nothing rather than guessing. A `use` that passes no literal atom resolves through the ordinary body, so the feature is purely additive.
+
+The token walker cannot evaluate conditionals, so a `use` nested in a compile-time branch (`on_ee do use X end`) is included unconditionally. This over-includes candidate names; it never removes one.
+
+`entry.bodies()` returns the ordinary body plus every dispatch target. `findModulesWhoseUsingImports` uses it, because the references slow path asks which modules *could* inject a name rather than which one a given `use` site selects.
+
 `lookupInUsingEntry(moduleName, fn, consumerOpts, visited)` is the recursive lookup. `lookupThroughUse` calls it with full consumer opts from `ExtractUsesWithOpts`. `ParseKeywordModuleOpts` parses `key: Module` pairs from use call opts strings, with alias resolution.
 
 ## References — injector scan

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,9 +62,11 @@ def controller do
 end
 ```
 
-`usingDispatchParam` recognises this only when `apply/3` targets `__MODULE__` **and** dispatches on that clause's own parameter — a literal function name or another module is not atom dispatch. When it matches, `parseDispatchBodies` parses each `def name do quote do ... end end` in the file into its own `usingBody`, stored in `usingCacheEntry.dispatch` keyed by function name. Nothing is merged across targets.
+`usingDispatchParam` recognises this only when `apply/3` targets `__MODULE__` **and** dispatches on that clause's own parameter — a literal function name or another module is not atom dispatch. Runtime parsing is scoped to the indexed module when a file defines multiple modules. When dispatch matches, `parseDispatchBodies` parses each `def name do quote do ... end end` in that module into its own `usingBody`, stored in `usingCacheEntry.dispatch` keyed by function name. Nothing is merged across targets.
 
-Selection happens at lookup time from the literal atom at the `use` site (`UseCall.Which`, or `UseCall.WhichKey` for the `use Mod, live_view: opts` form). `entry.bodyFor(which)` returns the matching body, or nil when the atom names no target — injecting nothing rather than guessing. A `use` that passes no literal atom resolves through the ordinary body, so the feature is purely additive.
+Selection happens at lookup time from the literal atom at the `use` site (`UseCall.Which`, or `UseCall.WhichKey` for the `use Mod, live_view: opts` form). `entry.bodyFor(which)` returns the matching body, or nil when the atom names no target — injecting nothing rather than guessing. A `use` that passes no literal atom resolves through the ordinary body, so the feature is purely additive. Completion, injected-alias merging, callback lookup, definitions, and references all select the same body.
+
+Transitive uses retain their complete `UseCall`, including the dispatch atom and keyword options. Visited keys include both module and dispatch target, which permits legitimate same-module chains such as `:api_controller` using `:controller` while still breaking real cycles. Local quoted helpers invoked with `unquote(helper())` are followed recursively.
 
 The token walker cannot evaluate conditionals, so a `use` nested in a compile-time branch (`on_ee do use X end`) is included unconditionally. This over-includes candidate names; it never removes one.
 

--- a/internal/lsp/elixir.go
+++ b/internal/lsp/elixir.go
@@ -1326,6 +1326,23 @@ func extractUsesFromTokens(source []byte, tokens []parser.Token) []string {
 type UseCall struct {
 	Module string            // the module being used (alias-resolved)
 	Opts   map[string]string // keyword args: opt_key → module name (alias-resolved)
+
+	// Which is the literal atom passed as the second argument, e.g. "controller"
+	// for `use MyAppWeb, :controller`. WhichKey is the first keyword key, e.g.
+	// "live_view" for `use MyAppWeb, live_view: :no_sentry_context`. Both feed
+	// atom-dispatch __using__ resolution and are empty otherwise.
+	Which    string
+	WhichKey string
+}
+
+// dispatchAtom is the name an atom-dispatch __using__ dispatches on, preferring
+// the bare atom form. Empty when the `use` passes no literal atom, which keeps
+// dispatch resolution off unless the target is named explicitly.
+func (u UseCall) dispatchAtom() string {
+	if u.Which != "" {
+		return u.Which
+	}
+	return u.WhichKey
 }
 
 // ExtractUsesWithOpts parses all `use Module` and `use Module, key: Val`
@@ -1354,13 +1371,39 @@ func extractUsesWithOptsFromTokens(source []byte, tokens []parser.Token, aliases
 		nk := tokNextSig(tokens, n, k)
 		if nk < n && tokens[nk].Kind == parser.TokComma {
 			opts := tokCollectKeywordModuleOpts(source, tokens, n, nk+1, aliases)
-			calls = append(calls, UseCall{Module: module, Opts: opts})
+			which, whichKey := tokCollectDispatchAtom(source, tokens, n, nk+1)
+			calls = append(calls, UseCall{Module: module, Opts: opts, Which: which, WhichKey: whichKey})
 		} else {
 			calls = append(calls, UseCall{Module: module})
 		}
 		i = k
 	}
 	return calls
+}
+
+// tokCollectDispatchAtom reads the second argument of a `use` call for the two
+// shapes an atom-dispatch __using__ accepts:
+//
+//	use MyAppWeb, :controller                     → which "controller"
+//	use MyAppWeb, live_view: :no_sentry_context   → whichKey "live_view"
+//
+// Only a literal atom (or literal keyword key) is reported. A variable or a
+// computed value yields empty strings, so the caller resolves nothing rather
+// than guessing.
+func tokCollectDispatchAtom(source []byte, tokens []parser.Token, n, pos int) (which, whichKey string) {
+	i := tokNextSig(tokens, n, pos)
+	if i >= n {
+		return "", ""
+	}
+	switch tokens[i].Kind {
+	case parser.TokAtom:
+		return strings.TrimPrefix(parser.TokenText(source, tokens[i]), ":"), ""
+	case parser.TokIdent:
+		if i+1 < n && tokens[i+1].Kind == parser.TokColon {
+			return "", parser.TokenText(source, tokens[i])
+		}
+	}
+	return "", ""
 }
 
 // tokCollectKeywordModuleOpts scans tokens starting at pos for keyword pairs
@@ -1406,6 +1449,156 @@ func tokCollectKeywordModuleOpts(source []byte, tokens []parser.Token, n, pos in
 		i++
 	}
 	return result
+}
+
+// usingBody is everything a single `quote do` block injects into a consumer
+// module. A plain `__using__` has exactly one; an atom-dispatch entrypoint has
+// one per dispatch target.
+type usingBody struct {
+	imports     []string               // modules imported, source order
+	inlineDefs  map[string][]inlineDef // function name → defs in the quote do block
+	transUses   []string               // modules used inside the body (double-use chains)
+	optBindings []optBinding           // dynamic imports/uses resolved from opts
+	aliases     map[string]string      // alias short name → full module
+}
+
+func (b *usingBody) isEmpty() bool {
+	return b == nil || (len(b.imports) == 0 && len(b.inlineDefs) == 0 &&
+		len(b.transUses) == 0 && len(b.optBindings) == 0 && len(b.aliases) == 0)
+}
+
+// usingDispatchParam reports the parameter name of an atom-dispatch __using__
+// clause, i.e. one whose entire body delegates to a sibling function named by
+// the atom the consumer passed:
+//
+//	defmacro __using__(which) when is_atom(which), do: apply(__MODULE__, which, [])
+//	defmacro __using__([{which, opts}]) when is_atom(which), do: apply(__MODULE__, which, [opts])
+//
+// It returns "" unless apply/3 targets __MODULE__ *and* dispatches on that
+// clause's own parameter. A literal function name or another module means the
+// call is not atom dispatch and must not be treated as such.
+func usingDispatchParam(source []byte, tokens []parser.Token) string {
+	n := len(tokens)
+	for i := 0; i < n; i++ {
+		if tokens[i].Kind != parser.TokDefmacro {
+			continue
+		}
+		j := tokNextSig(tokens, n, i+1)
+		if j >= n || tokens[j].Kind != parser.TokIdent || parser.TokenText(source, tokens[j]) != "__using__" {
+			continue
+		}
+		param, after := usingClauseParam(source, tokens, n, j+1)
+		if param == "" {
+			continue
+		}
+		if applyDispatchesOn(source, tokens, n, after, param) {
+			return param
+		}
+	}
+	return ""
+}
+
+// usingClauseParam reads the first parameter name of a __using__ clause,
+// accepting both `__using__(which)` and `__using__([{which, opts}])`. It
+// returns the name and the index to continue scanning from. A wildcard or
+// pattern that binds no plain name yields "".
+func usingClauseParam(source []byte, tokens []parser.Token, n, from int) (string, int) {
+	i := tokNextSig(tokens, n, from)
+	if i >= n || tokens[i].Kind != parser.TokOpenParen {
+		return "", from
+	}
+	// Skip list/tuple wrappers of the [{which, opts}] form to reach the first ident.
+	i = tokNextSig(tokens, n, i+1)
+	for i < n && (tokens[i].Kind == parser.TokOpenBracket || tokens[i].Kind == parser.TokOpenBrace) {
+		i = tokNextSig(tokens, n, i+1)
+	}
+	if i >= n || tokens[i].Kind != parser.TokIdent {
+		return "", from
+	}
+	name := parser.TokenText(source, tokens[i])
+	if name == "" || strings.HasPrefix(name, "_") {
+		return "", from
+	}
+	return name, i + 1
+}
+
+// applyDispatchesOn reports whether an `apply(__MODULE__, <param>, ...)` call
+// appears in the clause body starting at from, before the next __using__ clause.
+func applyDispatchesOn(source []byte, tokens []parser.Token, n, from int, param string) bool {
+	for i := from; i < n; i++ {
+		// Stop at the next clause so one clause's body cannot vouch for another.
+		if tokens[i].Kind == parser.TokDefmacro || tokens[i].Kind == parser.TokDef {
+			return false
+		}
+		if tokens[i].Kind != parser.TokIdent || parser.TokenText(source, tokens[i]) != "apply" {
+			continue
+		}
+		j := tokNextSig(tokens, n, i+1)
+		if j >= n || tokens[j].Kind != parser.TokOpenParen {
+			continue
+		}
+		j = tokNextSig(tokens, n, j+1)
+		if j >= n || tokens[j].Kind != parser.TokModule || parser.TokenText(source, tokens[j]) != "__MODULE__" {
+			continue
+		}
+		j = tokNextSig(tokens, n, j+1)
+		if j >= n || tokens[j].Kind != parser.TokComma {
+			continue
+		}
+		j = tokNextSig(tokens, n, j+1)
+		if j < n && tokens[j].Kind == parser.TokIdent && parser.TokenText(source, tokens[j]) == param {
+			return true
+		}
+	}
+	return false
+}
+
+// parseDispatchBodies parses every `def name do quote do ... end end` in text
+// into its own usingBody, keyed by function name. Callers select one by the
+// literal atom at the `use` site, so nothing is merged across targets.
+func parseDispatchBodies(text string) map[string]*usingBody {
+	source := []byte(text)
+	tokens := parser.Tokenize(source)
+	if usingDispatchParam(source, tokens) == "" {
+		return nil
+	}
+
+	lines := strings.Split(text, "\n")
+	fileAliases := extractAliasesFromTokens(source, tokens, -1)
+
+	n := len(tokens)
+	seen := make(map[string]bool)
+	bodies := make(map[string]*usingBody)
+	for i := 0; i < n; i++ {
+		if tokens[i].Kind != parser.TokDef {
+			continue
+		}
+		j := tokNextSig(tokens, n, i+1)
+		if j >= n || tokens[j].Kind != parser.TokIdent {
+			continue
+		}
+		name := parser.TokenText(source, tokens[j])
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+
+		imported, inlineDefs, transUses, optBindings, aliases := parseHelperQuoteBlock(lines, name, fileAliases)
+		body := &usingBody{
+			imports:     imported,
+			inlineDefs:  inlineDefs,
+			transUses:   transUses,
+			optBindings: optBindings,
+			aliases:     aliases,
+		}
+		if !body.isEmpty() {
+			bodies[name] = body
+		}
+	}
+	if len(bodies) == 0 {
+		return nil
+	}
+	return bodies
 }
 
 // inlineDef records a function or macro defined directly inside a __using__

--- a/internal/lsp/elixir.go
+++ b/internal/lsp/elixir.go
@@ -1156,6 +1156,17 @@ func skipToEndOfStatement(tokens []parser.Token, n, from int) int {
 // its `quote do` block, and extracts imports/uses/inline-defs/aliases from it.
 // Uses the tokenizer for correct heredoc and multi-line handling.
 func parseHelperQuoteBlock(lines []string, helperName string, fileAliases map[string]string) (imported []string, inlineDefs map[string][]inlineDef, transUses []string, optBindings []optBinding, aliases map[string]string) {
+	imported, inlineDefs, transUses, _, optBindings, aliases = parseHelperQuoteBlockDetailed(lines, helperName, fileAliases, make(map[string]bool))
+	return
+}
+
+func parseHelperQuoteBlockDetailed(lines []string, helperName string, fileAliases map[string]string, visited map[string]bool) (imported []string, inlineDefs map[string][]inlineDef, transUses []string, transUseCalls []UseCall, optBindings []optBinding, aliases map[string]string) {
+	if visited[helperName] {
+		return
+	}
+	visited[helperName] = true
+	defer delete(visited, helperName)
+
 	source := []byte(strings.Join(lines, "\n"))
 	tokens := parser.Tokenize(source)
 	n := len(tokens)
@@ -1195,9 +1206,8 @@ func parseHelperQuoteBlock(lines []string, helperName string, fileAliases map[st
 		switch tokens[i].Kind {
 		case parser.TokIdent:
 			if string(source[tokens[i].Start:tokens[i].End]) == "quote" {
-				j := tokNextSig(tokens, n, i+1)
-				if j < n && tokens[j].Kind == parser.TokDo {
-					quoteBodyStart = j + 1
+				if _, nextPos, hasDo := parser.ScanForwardToBlockDo(tokens, n, i+1); hasDo {
+					quoteBodyStart = nextPos
 				}
 			}
 		}
@@ -1226,9 +1236,17 @@ func parseHelperQuoteBlock(lines []string, helperName string, fileAliases map[st
 
 		case parser.TokUse:
 			j := tokNextSig(tokens, n, i+1)
-			mod, _ := tokCollectModuleName(source, tokens, n, j)
+			mod, k := tokCollectModuleName(source, tokens, n, j)
 			if mod != "" {
-				transUses = append(transUses, resolveAlias(mod))
+				resolved := resolveAlias(mod)
+				transUses = append(transUses, resolved)
+				call := UseCall{Module: resolved}
+				nk := tokNextSig(tokens, n, k)
+				if nk < n && tokens[nk].Kind == parser.TokComma {
+					call.Opts = tokCollectKeywordModuleOpts(source, tokens, n, nk+1, fileAliases)
+					call.Which, call.WhichKey = tokCollectDispatchAtom(source, tokens, n, nk+1)
+				}
+				transUseCalls = append(transUseCalls, call)
 			}
 
 		case parser.TokAlias:
@@ -1295,6 +1313,38 @@ func parseHelperQuoteBlock(lines []string, helperName string, fileAliases map[st
 				})
 			}
 			i = skipToEndOfStatement(tokens, n, nextPos) - 1
+
+		case parser.TokIdent:
+			if parser.TokenText(source, tok) != "unquote" {
+				continue
+			}
+			j := tokNextSig(tokens, n, i+1)
+			if j >= n || tokens[j].Kind != parser.TokOpenParen {
+				continue
+			}
+			j = tokNextSig(tokens, n, j+1)
+			if j >= n || tokens[j].Kind != parser.TokIdent {
+				continue
+			}
+			nestedName := parser.TokenText(source, tokens[j])
+			k := tokNextSig(tokens, n, j+1)
+			if k >= n || tokens[k].Kind != parser.TokOpenParen {
+				continue
+			}
+			nestedImports, nestedDefs, nestedUses, nestedCalls, nestedBindings, nestedAliases := parseHelperQuoteBlockDetailed(lines, nestedName, fileAliases, visited)
+			imported = append(imported, nestedImports...)
+			for name, defs := range nestedDefs {
+				inlineDefs[name] = append(inlineDefs[name], defs...)
+			}
+			transUses = append(transUses, nestedUses...)
+			transUseCalls = append(transUseCalls, nestedCalls...)
+			optBindings = append(optBindings, nestedBindings...)
+			for short, full := range nestedAliases {
+				if aliases == nil {
+					aliases = make(map[string]string)
+				}
+				aliases[short] = full
+			}
 		}
 	}
 	return
@@ -1397,13 +1447,28 @@ func tokCollectDispatchAtom(source []byte, tokens []parser.Token, n, pos int) (w
 	}
 	switch tokens[i].Kind {
 	case parser.TokAtom:
-		return strings.TrimPrefix(parser.TokenText(source, tokens[i]), ":"), ""
+		return dispatchAtomName(parser.TokenText(source, tokens[i])), ""
+	case parser.TokOpenBrace:
+		j := tokNextSig(tokens, n, i+1)
+		if j < n && tokens[j].Kind == parser.TokAtom {
+			return dispatchAtomName(parser.TokenText(source, tokens[j])), ""
+		}
 	case parser.TokIdent:
 		if i+1 < n && tokens[i+1].Kind == parser.TokColon {
 			return "", parser.TokenText(source, tokens[i])
 		}
 	}
 	return "", ""
+}
+
+func dispatchAtomName(text string) string {
+	name := strings.TrimPrefix(text, ":")
+	if len(name) >= 2 && name[0] == '"' && name[len(name)-1] == '"' {
+		if unquoted, err := strconv.Unquote(name); err == nil {
+			return unquoted
+		}
+	}
+	return name
 }
 
 // tokCollectKeywordModuleOpts scans tokens starting at pos for keyword pairs
@@ -1458,13 +1523,23 @@ type usingBody struct {
 	imports     []string               // modules imported, source order
 	inlineDefs  map[string][]inlineDef // function name → defs in the quote do block
 	transUses   []string               // modules used inside the body (double-use chains)
+	transCalls  []UseCall              // transitive uses with dispatch atom and opts preserved
 	optBindings []optBinding           // dynamic imports/uses resolved from opts
 	aliases     map[string]string      // alias short name → full module
 }
 
 func (b *usingBody) isEmpty() bool {
 	return b == nil || (len(b.imports) == 0 && len(b.inlineDefs) == 0 &&
-		len(b.transUses) == 0 && len(b.optBindings) == 0 && len(b.aliases) == 0)
+		len(b.transUses) == 0 && len(b.transCalls) == 0 && len(b.optBindings) == 0 && len(b.aliases) == 0)
+}
+
+func (b *usingBody) hasTransCall(moduleName string) bool {
+	for i := range b.transCalls {
+		if b.transCalls[i].Module == moduleName {
+			return true
+		}
+	}
+	return false
 }
 
 // usingDispatchParam reports the parameter name of an atom-dispatch __using__
@@ -1553,6 +1628,53 @@ func applyDispatchesOn(source []byte, tokens []parser.Token, n, from int, param 
 	return false
 }
 
+// sourceForModule limits runtime __using__ parsing to one module in files that
+// define multiple modules. Leading newlines preserve the original token line
+// numbers used for definition locations.
+func sourceForModule(text, moduleName string) (string, bool) {
+	source := []byte(text)
+	tokens := parser.Tokenize(source)
+	type frame struct {
+		name  string
+		depth int
+		start int
+	}
+	var stack []frame
+	depth := 0
+
+	for i := 0; i < len(tokens); i++ {
+		switch tokens[i].Kind {
+		case parser.TokDo, parser.TokFn:
+			parser.TrackBlockDepth(tokens[i].Kind, &depth)
+		case parser.TokEnd:
+			prevDepth := depth
+			parser.TrackBlockDepth(tokens[i].Kind, &depth)
+			if len(stack) == 0 || stack[len(stack)-1].depth != prevDepth {
+				continue
+			}
+			closed := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if closed.name == moduleName {
+				prefix := strings.Repeat("\n", tokens[closed.start].Line-1)
+				return prefix + string(source[tokens[closed.start].Start:tokens[i].End]), true
+			}
+		case parser.TokDefmodule:
+			parent := ""
+			if len(stack) > 0 {
+				parent = stack[len(stack)-1].name
+			}
+			name, nextPos, hasDo := tokParseModuleDef(source, tokens, i+1, parent)
+			if name == "" || !hasDo {
+				continue
+			}
+			depth++
+			stack = append(stack, frame{name: name, depth: depth, start: i})
+			i = nextPos - 1
+		}
+	}
+	return "", false
+}
+
 // parseDispatchBodies parses every `def name do quote do ... end end` in text
 // into its own usingBody, keyed by function name. Callers select one by the
 // literal atom at the `use` site, so nothing is merged across targets.
@@ -1583,11 +1705,12 @@ func parseDispatchBodies(text string) map[string]*usingBody {
 		}
 		seen[name] = true
 
-		imported, inlineDefs, transUses, optBindings, aliases := parseHelperQuoteBlock(lines, name, fileAliases)
+		imported, inlineDefs, transUses, transCalls, optBindings, aliases := parseHelperQuoteBlockDetailed(lines, name, fileAliases, make(map[string]bool))
 		body := &usingBody{
 			imports:     imported,
 			inlineDefs:  inlineDefs,
 			transUses:   transUses,
+			transCalls:  transCalls,
 			optBindings: optBindings,
 			aliases:     aliases,
 		}
@@ -1620,6 +1743,11 @@ type inlineDef struct {
 // Uses the tokenizer so that heredocs, multi-line expressions, and comments are
 // handled correctly without line-joining heuristics.
 func parseUsingBody(text string) (imported []string, inlineDefs map[string][]inlineDef, transUses []string, optBindings []optBinding, aliases map[string]string) {
+	imported, inlineDefs, transUses, _, optBindings, aliases = parseUsingBodyDetailed(text)
+	return
+}
+
+func parseUsingBodyDetailed(text string) (imported []string, inlineDefs map[string][]inlineDef, transUses []string, transCalls []UseCall, optBindings []optBinding, aliases map[string]string) {
 	source := []byte(text)
 	tokens := parser.Tokenize(source)
 	n := len(tokens)
@@ -1836,7 +1964,15 @@ func parseUsingBody(text string) (imported []string, inlineDefs map[string][]inl
 			// use Module
 			modName, k := collectModuleName(j)
 			if modName != "" {
-				transUses = append(transUses, resolveAlias(modName))
+				resolved := resolveAlias(modName)
+				transUses = append(transUses, resolved)
+				call := UseCall{Module: resolved}
+				nk := nextSig(k)
+				if nk < n && tokens[nk].Kind == parser.TokComma {
+					call.Opts = tokCollectKeywordModuleOpts(source, tokens, n, nk+1, fileAliases)
+					call.Which, call.WhichKey = tokCollectDispatchAtom(source, tokens, n, nk+1)
+				}
+				transCalls = append(transCalls, call)
 			}
 			i = k
 
@@ -1982,13 +2118,14 @@ func parseUsingBody(text string) (imported []string, inlineDefs map[string][]inl
 			// helper_name(opts) where helper_name is a def/defp in the same file.
 			// Only at statement start to avoid matching function calls inside expressions.
 			if isStmtStart && j < n && tokens[j].Kind == parser.TokOpenParen && !parser.IsElixirKeyword(identName) {
-				helperImported, helperDefs, helperTransUses, helperBindings, helperAliases := parseHelperQuoteBlock(lines, identName, fileAliases)
+				helperImported, helperDefs, helperTransUses, helperCalls, helperBindings, helperAliases := parseHelperQuoteBlockDetailed(lines, identName, fileAliases, make(map[string]bool))
 				if helperImported != nil {
 					imported = append(imported, helperImported...)
 					for hk, hv := range helperDefs {
 						inlineDefs[hk] = append(inlineDefs[hk], hv...)
 					}
 					transUses = append(transUses, helperTransUses...)
+					transCalls = append(transCalls, helperCalls...)
 					optBindings = append(optBindings, helperBindings...)
 				}
 				for hk, hv := range helperAliases {

--- a/internal/lsp/elixir_test.go
+++ b/internal/lsp/elixir_test.go
@@ -2307,6 +2307,23 @@ func TestExtractUsesWithOpts(t *testing.T) {
 			t.Errorf("repo: want MyRepo, got %q", calls[0].Opts["repo"])
 		}
 	})
+
+	for _, tt := range []struct {
+		name string
+		use  string
+		want string
+	}{
+		{name: "bare dispatch atom", use: ":controller", want: "controller"},
+		{name: "quoted dispatch atom", use: `:"controller"`, want: "controller"},
+		{name: "tuple dispatch atom", use: "{:controller, []}", want: "controller"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := ExtractUsesWithOpts("defmodule Foo do\n  use MyAppWeb, "+tt.use+"\nend", nil)
+			if len(calls) != 1 || calls[0].dispatchAtom() != tt.want {
+				t.Fatalf("dispatch atom: want %q, got %#v", tt.want, calls)
+			}
+		})
+	}
 }
 
 func TestFindBufferFunctions(t *testing.T) {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1959,8 +1959,8 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 		aliases := tf.ExtractAliases()
 		s.mergeAliasesFromUseTokenized(tf, aliases)
 		visitedCompletion := make(map[string]bool)
-		for _, usedModule := range tf.ExtractUses() {
-			s.addCompletionsFromUsing(resolveModule(usedModule, aliases), funcPrefix, seen, &items, visitedCompletion, inPipe, s.snippetSupport)
+		for _, useCall := range tf.ExtractUsesWithOpts(aliases) {
+			s.addCompletionsFromUsingFor(useCall.Module, useCall.dispatchAtom(), useCall.Opts, funcPrefix, seen, &items, visitedCompletion, inPipe, s.snippetSupport)
 		}
 
 		// Variables in scope via tree-sitter
@@ -2042,7 +2042,7 @@ func (s *Server) cachedUsingWithPath(moduleName, knownPath string) *usingCacheEn
 			return entry
 		}
 		// File changed — re-parse using the cached path (no LookupModule needed)
-		if newEntry := s.parseUsingFile(entry.filePath); newEntry != nil {
+		if newEntry := s.parseUsingFile(entry.filePath, moduleName); newEntry != nil {
 			s.usingCacheMu.Lock()
 			s.usingCache[moduleName] = newEntry
 			s.usingCacheMu.Unlock()
@@ -2061,7 +2061,7 @@ func (s *Server) cachedUsingWithPath(moduleName, knownPath string) *usingCacheEn
 		filePath = modResults[0].FilePath
 	}
 	filePath = filepath.Clean(filePath)
-	newEntry := s.parseUsingFile(filePath)
+	newEntry := s.parseUsingFile(filePath, moduleName)
 	if newEntry == nil {
 		return nil
 	}
@@ -2071,7 +2071,7 @@ func (s *Server) cachedUsingWithPath(moduleName, knownPath string) *usingCacheEn
 	return newEntry
 }
 
-func (s *Server) parseUsingFile(filePath string) *usingCacheEntry {
+func (s *Server) parseUsingFile(filePath, moduleName string) *usingCacheEntry {
 	f, err := os.Open(filePath)
 	if err != nil {
 		return nil
@@ -2087,7 +2087,13 @@ func (s *Server) parseUsingFile(filePath string) *usingCacheEntry {
 		return nil
 	}
 	text := string(fileData)
-	imported, inlineDefs, transUses, optBindings, aliases := parseUsingBody(text)
+	// The common one-module-per-file case avoids an extra tokenization.
+	if strings.Count(text, "defmodule") > 1 {
+		if scoped, ok := sourceForModule(text, moduleName); ok {
+			text = scoped
+		}
+	}
+	imported, inlineDefs, transUses, transCalls, optBindings, aliases := parseUsingBodyDetailed(text)
 	return &usingCacheEntry{
 		mtime:    info.ModTime().UnixNano(),
 		filePath: filePath,
@@ -2095,6 +2101,7 @@ func (s *Server) parseUsingFile(filePath string) *usingCacheEntry {
 			imports:     imported,
 			inlineDefs:  inlineDefs,
 			transUses:   transUses,
+			transCalls:  transCalls,
 			optBindings: optBindings,
 			aliases:     aliases,
 		},
@@ -2164,13 +2171,18 @@ func (e *usingCacheEntry) bodies() []*usingBody {
 	return out
 }
 
+func usingVisitKey(moduleName, which string) string {
+	return moduleName + "\x00" + which
+}
+
 // lookupInUsingEntryFor is lookupInUsingEntry with the dispatch atom from the
 // `use` site (empty for an ordinary `use Module`).
 func (s *Server) lookupInUsingEntryFor(moduleName, functionName, which string, consumerOpts map[string]string, visited map[string]bool) []store.LookupResult {
-	if visited[moduleName] {
+	visitKey := usingVisitKey(moduleName, which)
+	if visited[visitKey] {
 		return nil
 	}
-	visited[moduleName] = true
+	visited[visitKey] = true
 
 	entry := s.cachedUsing(moduleName)
 	if entry == nil {
@@ -2234,7 +2246,16 @@ func (s *Server) lookupInUsingEntryFor(moduleName, functionName, which string, c
 	}
 
 	// Transitive uses: use Module inside the __using__ body (double-use chains)
+	for k := len(body.transCalls) - 1; k >= 0; k-- {
+		call := body.transCalls[k]
+		if result := s.lookupInUsingEntryFor(call.Module, functionName, call.dispatchAtom(), call.Opts, visited); result != nil {
+			return result
+		}
+	}
 	for k := len(body.transUses) - 1; k >= 0; k-- {
+		if body.hasTransCall(body.transUses[k]) {
+			continue
+		}
 		if result := s.lookupInUsingEntry(body.transUses[k], functionName, nil, visited); result != nil {
 			return result
 		}
@@ -2253,10 +2274,11 @@ func (s *Server) resolveModuleViaUseChainWithOpts(moduleName, functionName strin
 // resolveModuleViaUseChainFor is resolveModuleViaUseChainWithOpts with the
 // dispatch atom from the `use` site (empty for an ordinary `use Module`).
 func (s *Server) resolveModuleViaUseChainFor(moduleName, functionName, which string, consumerOpts map[string]string, visited map[string]bool) string {
-	if visited[moduleName] {
+	visitKey := usingVisitKey(moduleName, which)
+	if visited[visitKey] {
 		return ""
 	}
-	visited[moduleName] = true
+	visited[visitKey] = true
 
 	entry := s.cachedUsing(moduleName)
 	if entry == nil {
@@ -2299,7 +2321,16 @@ func (s *Server) resolveModuleViaUseChainFor(moduleName, functionName, which str
 		}
 	}
 
+	for k := len(body.transCalls) - 1; k >= 0; k-- {
+		call := body.transCalls[k]
+		if mod := s.resolveModuleViaUseChainFor(call.Module, functionName, call.dispatchAtom(), call.Opts, visited); mod != "" {
+			return mod
+		}
+	}
 	for k := len(body.transUses) - 1; k >= 0; k-- {
+		if body.hasTransCall(body.transUses[k]) {
+			continue
+		}
 		if mod := s.resolveModuleViaUseChainWithOpts(body.transUses[k], functionName, nil, visited); mod != "" {
 			return mod
 		}
@@ -2413,18 +2444,23 @@ func (s *Server) findModulesWhoseUsingImports(targetModule string) []string {
 
 // addCompletionsFromUsing adds completion items injected by a module's __using__
 // body — inline defs, imported functions, and transitive uses — into items.
-func (s *Server) addCompletionsFromUsing(moduleName, funcPrefix string, seen map[string]bool, items *[]protocol.CompletionItem, visited map[string]bool, inPipe bool, useSnippets bool) {
-	if visited[moduleName] {
+func (s *Server) addCompletionsFromUsingFor(moduleName, which string, consumerOpts map[string]string, funcPrefix string, seen map[string]bool, items *[]protocol.CompletionItem, visited map[string]bool, inPipe bool, useSnippets bool) {
+	visitKey := usingVisitKey(moduleName, which)
+	if visited[visitKey] {
 		return
 	}
-	visited[moduleName] = true
+	visited[visitKey] = true
 
 	entry := s.cachedUsing(moduleName)
 	if entry == nil {
 		return
 	}
+	body := entry.bodyFor(which)
+	if body == nil {
+		return
+	}
 
-	for funcName, defs := range entry.inlineDefs {
+	for funcName, defs := range body.inlineDefs {
 		if !strings.HasPrefix(funcName, funcPrefix) {
 			continue
 		}
@@ -2450,10 +2486,10 @@ func (s *Server) addCompletionsFromUsing(moduleName, funcPrefix string, seen map
 		}
 	}
 
-	for _, mod := range entry.imports {
+	addModule := func(mod string) {
 		results, err := s.store.ListModuleFunctions(mod, true)
 		if err != nil {
-			continue
+			return
 		}
 		for _, r := range results {
 			key := funcKey(r.Function, r.Arity)
@@ -2476,9 +2512,33 @@ func (s *Server) addCompletionsFromUsing(moduleName, funcPrefix string, seen map
 			}
 		}
 	}
+	for _, mod := range body.imports {
+		addModule(mod)
+	}
 
-	for _, transModule := range entry.transUses {
-		s.addCompletionsFromUsing(transModule, funcPrefix, seen, items, visited, inPipe, useSnippets)
+	for _, binding := range body.optBindings {
+		mod := consumerOpts[binding.optKey]
+		if mod == "" {
+			mod = binding.defaultMod
+		}
+		if mod == "" {
+			continue
+		}
+		switch binding.kind {
+		case "import":
+			addModule(mod)
+		case "use":
+			s.addCompletionsFromUsingFor(mod, "", nil, funcPrefix, seen, items, visited, inPipe, useSnippets)
+		}
+	}
+
+	for _, call := range body.transCalls {
+		s.addCompletionsFromUsingFor(call.Module, call.dispatchAtom(), call.Opts, funcPrefix, seen, items, visited, inPipe, useSnippets)
+	}
+	for _, transModule := range body.transUses {
+		if !body.hasTransCall(transModule) {
+			s.addCompletionsFromUsingFor(transModule, "", nil, funcPrefix, seen, items, visited, inPipe, useSnippets)
+		}
 	}
 }
 
@@ -2557,30 +2617,52 @@ func (s *Server) mergeAliasesFromUseTokenized(tf *TokenizedFile, aliases map[str
 func (s *Server) mergeAliasesFromUseCalls(useCalls []UseCall, aliases map[string]string) {
 	visited := make(map[string]bool)
 	for _, uc := range useCalls {
-		s.mergeAliasesFromUsingEntry(uc.Module, aliases, visited)
+		s.mergeAliasesFromUsingEntryFor(uc.Module, uc.dispatchAtom(), uc.Opts, aliases, visited)
 	}
 }
 
-func (s *Server) mergeAliasesFromUsingEntry(moduleName string, aliases map[string]string, visited map[string]bool) {
-	if visited[moduleName] {
+func (s *Server) mergeAliasesFromUsingEntryFor(moduleName, which string, consumerOpts map[string]string, aliases map[string]string, visited map[string]bool) {
+	visitKey := usingVisitKey(moduleName, which)
+	if visited[visitKey] {
 		return
 	}
-	visited[moduleName] = true
+	visited[visitKey] = true
 
 	entry := s.cachedUsing(moduleName)
 	if entry == nil {
 		return
 	}
+	body := entry.bodyFor(which)
+	if body == nil {
+		return
+	}
 
-	for short, full := range entry.aliases {
+	for short, full := range body.aliases {
 		if _, exists := aliases[short]; !exists {
 			aliases[short] = full
 		}
 	}
+	for _, binding := range body.optBindings {
+		if binding.kind != "use" {
+			continue
+		}
+		mod := consumerOpts[binding.optKey]
+		if mod == "" {
+			mod = binding.defaultMod
+		}
+		if mod != "" {
+			s.mergeAliasesFromUsingEntryFor(mod, "", nil, aliases, visited)
+		}
+	}
 
 	// Follow transitive uses
-	for _, transModule := range entry.transUses {
-		s.mergeAliasesFromUsingEntry(transModule, aliases, visited)
+	for _, call := range body.transCalls {
+		s.mergeAliasesFromUsingEntryFor(call.Module, call.dispatchAtom(), call.Opts, aliases, visited)
+	}
+	for _, transModule := range body.transUses {
+		if !body.hasTransCall(transModule) {
+			s.mergeAliasesFromUsingEntryFor(transModule, "", nil, aliases, visited)
+		}
 	}
 }
 
@@ -2998,21 +3080,21 @@ func extractImplAnnotation(lines []string, lineNum int) string {
 // definitions matching functionName/arity. This resolves dynamic `use unquote(mod)`
 // patterns where the concrete module appears as a keyword opt in the chain.
 func (s *Server) findCallbacksViaUseChain(text, functionName string, arity int, aliases map[string]string) []store.CallbackResult {
-	uses := ExtractUses(text)
+	uses := ExtractUsesWithOpts(text, aliases)
 	visited := make(map[string]bool)
 	var results []store.CallbackResult
-	for _, moduleName := range uses {
-		moduleName = resolveModule(moduleName, aliases)
-		s.collectCallbacksInChain(moduleName, functionName, arity, visited, &results)
+	for _, call := range uses {
+		s.collectCallbacksInChainFor(call.Module, call.dispatchAtom(), functionName, arity, visited, &results)
 	}
 	return results
 }
 
-func (s *Server) collectCallbacksInChain(moduleName, functionName string, arity int, visited map[string]bool, results *[]store.CallbackResult) {
-	if visited[moduleName] {
+func (s *Server) collectCallbacksInChainFor(moduleName, which, functionName string, arity int, visited map[string]bool, results *[]store.CallbackResult) {
+	visitKey := usingVisitKey(moduleName, which)
+	if visited[visitKey] {
 		return
 	}
-	visited[moduleName] = true
+	visited[visitKey] = true
 
 	if callbacks, err := s.store.LookupCallbackDef(moduleName, functionName); err == nil {
 		for _, cb := range callbacks {
@@ -3026,8 +3108,17 @@ func (s *Server) collectCallbacksInChain(moduleName, functionName string, arity 
 	if entry == nil {
 		return
 	}
-	for _, transModule := range entry.transUses {
-		s.collectCallbacksInChain(transModule, functionName, arity, visited, results)
+	body := entry.bodyFor(which)
+	if body == nil {
+		return
+	}
+	for _, call := range body.transCalls {
+		s.collectCallbacksInChainFor(call.Module, call.dispatchAtom(), functionName, arity, visited, results)
+	}
+	for _, transModule := range body.transUses {
+		if !body.hasTransCall(transModule) {
+			s.collectCallbacksInChainFor(transModule, "", functionName, arity, visited, results)
+		}
 	}
 }
 
@@ -4250,7 +4341,7 @@ func (s *Server) References(ctx context.Context, params *protocol.ReferenceParam
 		useCalls := tf.ExtractUsesWithOpts(aliases)
 		visited := make(map[string]bool)
 		for _, uc := range useCalls {
-			if s.lookupInUsingEntry(uc.Module, functionName, uc.Opts, visited) != nil {
+			if s.lookupInUsingEntryFor(uc.Module, functionName, uc.dispatchAtom(), uc.Opts, visited) != nil {
 				injectors = append(injectors, uc.Module)
 				s.debugf("References: opt-binding injector for %s: %s", functionName, uc.Module)
 			}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -48,13 +48,15 @@ type optBinding struct {
 // body, keyed by module name. Storing filePath avoids a LookupModule query on
 // cache hits; mtime invalidates the entry when the source file changes.
 type usingCacheEntry struct {
-	mtime       int64
-	filePath    string
-	imports     []string               // modules imported in __using__, source order
-	inlineDefs  map[string][]inlineDef // function name → inline defs in quote do block
-	transUses   []string               // modules used inside __using__ body (double-use chains)
-	optBindings []optBinding           // dynamic imports/uses resolved from opts
-	aliases     map[string]string      // alias short name → full module injected by __using__
+	mtime    int64
+	filePath string
+	usingBody
+
+	// dispatch holds one body per target of an atom-dispatch __using__, keyed by
+	// the atom the consumer passes (`use MyAppWeb, :controller` → "controller").
+	// Nil for ordinary __using__ macros. Selection happens at lookup time from
+	// the literal atom, so targets never merge.
+	dispatch map[string]*usingBody
 }
 
 type erlangBuildRootState struct {
@@ -2084,15 +2086,19 @@ func (s *Server) parseUsingFile(filePath string) *usingCacheEntry {
 	if err != nil {
 		return nil
 	}
-	imported, inlineDefs, transUses, optBindings, aliases := parseUsingBody(string(fileData))
+	text := string(fileData)
+	imported, inlineDefs, transUses, optBindings, aliases := parseUsingBody(text)
 	return &usingCacheEntry{
-		mtime:       info.ModTime().UnixNano(),
-		filePath:    filePath,
-		imports:     imported,
-		inlineDefs:  inlineDefs,
-		transUses:   transUses,
-		optBindings: optBindings,
-		aliases:     aliases,
+		mtime:    info.ModTime().UnixNano(),
+		filePath: filePath,
+		usingBody: usingBody{
+			imports:     imported,
+			inlineDefs:  inlineDefs,
+			transUses:   transUses,
+			optBindings: optBindings,
+			aliases:     aliases,
+		},
+		dispatch: parseDispatchBodies(text),
 	}
 }
 
@@ -2120,7 +2126,7 @@ func (s *Server) lookupThroughUse(text, functionName string, aliases map[string]
 	visited := make(map[string]bool)
 
 	for i := len(useCalls) - 1; i >= 0; i-- {
-		if result := s.lookupInUsingEntry(useCalls[i].Module, functionName, useCalls[i].Opts, visited); result != nil {
+		if result := s.lookupInUsingEntryFor(useCalls[i].Module, functionName, useCalls[i].dispatchAtom(), useCalls[i].Opts, visited); result != nil {
 			return result
 		}
 	}
@@ -2132,6 +2138,35 @@ func (s *Server) lookupThroughUse(text, functionName string, aliases map[string]
 // consumerOpts are the keyword args from the `use Module, key: Val` call and
 // are used to resolve dynamic imports like `import unquote(mod)`.
 func (s *Server) lookupInUsingEntry(moduleName, functionName string, consumerOpts map[string]string, visited map[string]bool) []store.LookupResult {
+	return s.lookupInUsingEntryFor(moduleName, functionName, "", consumerOpts, visited)
+}
+
+// bodyFor picks the injected body for a `use` call. An ordinary __using__ has a
+// single body. An atom-dispatch entrypoint has one per target, selected by the
+// literal atom; an atom that names no target injects nothing, because guessing
+// a target would merge unrelated blocks.
+func (e *usingCacheEntry) bodyFor(which string) *usingBody {
+	if e.dispatch != nil && which != "" {
+		return e.dispatch[which]
+	}
+	return &e.usingBody
+}
+
+// bodies returns every body a module's __using__ can inject: the ordinary one
+// plus each atom-dispatch target. Used where the question is which modules
+// *could* inject a name, rather than which one a given `use` site selects.
+func (e *usingCacheEntry) bodies() []*usingBody {
+	out := make([]*usingBody, 0, 1+len(e.dispatch))
+	out = append(out, &e.usingBody)
+	for _, b := range e.dispatch {
+		out = append(out, b)
+	}
+	return out
+}
+
+// lookupInUsingEntryFor is lookupInUsingEntry with the dispatch atom from the
+// `use` site (empty for an ordinary `use Module`).
+func (s *Server) lookupInUsingEntryFor(moduleName, functionName, which string, consumerOpts map[string]string, visited map[string]bool) []store.LookupResult {
 	if visited[moduleName] {
 		return nil
 	}
@@ -2141,9 +2176,13 @@ func (s *Server) lookupInUsingEntry(moduleName, functionName string, consumerOpt
 	if entry == nil {
 		return nil
 	}
+	body := entry.bodyFor(which)
+	if body == nil {
+		return nil
+	}
 
 	// Inline defs take priority: directly injected by the quote do block
-	if defs, ok := entry.inlineDefs[functionName]; ok {
+	if defs, ok := body.inlineDefs[functionName]; ok {
 		var results []store.LookupResult
 		for _, d := range defs {
 			results = append(results, store.LookupResult{FilePath: entry.filePath, Line: d.line})
@@ -2152,13 +2191,13 @@ func (s *Server) lookupInUsingEntry(moduleName, functionName string, consumerOpt
 	}
 
 	// Static imports
-	for j := len(entry.imports) - 1; j >= 0; j-- {
+	for j := len(body.imports) - 1; j >= 0; j-- {
 		var results []store.LookupResult
 		var err error
 		if s.followDelegates {
-			results, err = s.store.LookupFollowDelegate(entry.imports[j], functionName)
+			results, err = s.store.LookupFollowDelegate(body.imports[j], functionName)
 		} else {
-			results, err = s.store.LookupFunction(entry.imports[j], functionName)
+			results, err = s.store.LookupFunction(body.imports[j], functionName)
 		}
 		if err != nil || len(results) == 0 {
 			continue
@@ -2167,7 +2206,7 @@ func (s *Server) lookupInUsingEntry(moduleName, functionName string, consumerOpt
 	}
 
 	// Dynamic imports/uses driven by opts (e.g. `import unquote(mod)`)
-	for _, b := range entry.optBindings {
+	for _, b := range body.optBindings {
 		mod := consumerOpts[b.optKey]
 		if mod == "" {
 			mod = b.defaultMod
@@ -2195,8 +2234,8 @@ func (s *Server) lookupInUsingEntry(moduleName, functionName string, consumerOpt
 	}
 
 	// Transitive uses: use Module inside the __using__ body (double-use chains)
-	for k := len(entry.transUses) - 1; k >= 0; k-- {
-		if result := s.lookupInUsingEntry(entry.transUses[k], functionName, nil, visited); result != nil {
+	for k := len(body.transUses) - 1; k >= 0; k-- {
+		if result := s.lookupInUsingEntry(body.transUses[k], functionName, nil, visited); result != nil {
 			return result
 		}
 	}
@@ -2208,6 +2247,12 @@ func (s *Server) lookupInUsingEntry(moduleName, functionName string, consumerOpt
 // resolveModuleViaUseChainWithOpts is like resolveModuleViaUseChain but uses
 // consumer-provided opts to resolve dynamic imports (e.g. `import unquote(mod)`).
 func (s *Server) resolveModuleViaUseChainWithOpts(moduleName, functionName string, consumerOpts map[string]string, visited map[string]bool) string {
+	return s.resolveModuleViaUseChainFor(moduleName, functionName, "", consumerOpts, visited)
+}
+
+// resolveModuleViaUseChainFor is resolveModuleViaUseChainWithOpts with the
+// dispatch atom from the `use` site (empty for an ordinary `use Module`).
+func (s *Server) resolveModuleViaUseChainFor(moduleName, functionName, which string, consumerOpts map[string]string, visited map[string]bool) string {
 	if visited[moduleName] {
 		return ""
 	}
@@ -2217,14 +2262,24 @@ func (s *Server) resolveModuleViaUseChainWithOpts(moduleName, functionName strin
 	if entry == nil {
 		return ""
 	}
+	body := entry.bodyFor(which)
+	if body == nil {
+		return ""
+	}
 
-	for j := len(entry.imports) - 1; j >= 0; j-- {
-		if results, err := s.store.LookupFunction(entry.imports[j], functionName); err == nil && len(results) > 0 {
-			return entry.imports[j]
+	// Functions defined directly in the quote do block belong to the module
+	// that injected them, not to any imported module.
+	if _, ok := body.inlineDefs[functionName]; ok {
+		return moduleName
+	}
+
+	for j := len(body.imports) - 1; j >= 0; j-- {
+		if results, err := s.store.LookupFunction(body.imports[j], functionName); err == nil && len(results) > 0 {
+			return body.imports[j]
 		}
 	}
 
-	for _, b := range entry.optBindings {
+	for _, b := range body.optBindings {
 		mod := consumerOpts[b.optKey]
 		if mod == "" {
 			mod = b.defaultMod
@@ -2244,8 +2299,8 @@ func (s *Server) resolveModuleViaUseChainWithOpts(moduleName, functionName strin
 		}
 	}
 
-	for k := len(entry.transUses) - 1; k >= 0; k-- {
-		if mod := s.resolveModuleViaUseChainWithOpts(entry.transUses[k], functionName, nil, visited); mod != "" {
+	for k := len(body.transUses) - 1; k >= 0; k-- {
+		if mod := s.resolveModuleViaUseChainWithOpts(body.transUses[k], functionName, nil, visited); mod != "" {
 			return mod
 		}
 	}
@@ -2302,10 +2357,17 @@ func (s *Server) findModulesWhoseUsingImports(targetModule string) []string {
 	seen := make(map[string]bool)
 	var directInjectors []string
 	for _, c := range entries {
-		for _, imp := range c.entry.imports {
-			if imp == targetModule {
-				directInjectors = append(directInjectors, c.module)
-				seen[c.module] = true
+		for _, body := range c.entry.bodies() {
+			found := false
+			for _, imp := range body.imports {
+				if imp == targetModule {
+					directInjectors = append(directInjectors, c.module)
+					seen[c.module] = true
+					found = true
+					break
+				}
+			}
+			if found {
 				break
 			}
 		}
@@ -2328,11 +2390,18 @@ func (s *Server) findModulesWhoseUsingImports(targetModule string) []string {
 			if seen[c.module] {
 				continue
 			}
-			for _, tu := range c.entry.transUses {
-				if tu == current {
-					seen[c.module] = true
-					allInjectors = append(allInjectors, c.module)
-					queue = append(queue, c.module)
+			for _, body := range c.entry.bodies() {
+				found := false
+				for _, tu := range body.transUses {
+					if tu == current {
+						seen[c.module] = true
+						allInjectors = append(allInjectors, c.module)
+						queue = append(queue, c.module)
+						found = true
+						break
+					}
+				}
+				if found {
 					break
 				}
 			}
@@ -2438,7 +2507,7 @@ func (s *Server) resolveBareFunctionModule(filePath, text string, tf *TokenizedF
 	// Use chains — use opts-aware resolution so `import unquote(mod)` patterns
 	// resolve to the consumer-provided module rather than always using the default.
 	for _, uc := range tf.ExtractUsesWithOpts(aliases) {
-		if mod := s.resolveModuleViaUseChainWithOpts(uc.Module, functionName, uc.Opts, map[string]bool{}); mod != "" {
+		if mod := s.resolveModuleViaUseChainFor(uc.Module, functionName, uc.dispatchAtom(), uc.Opts, map[string]bool{}); mod != "" {
 			return mod
 		}
 	}

--- a/internal/lsp/using_dispatch_test.go
+++ b/internal/lsp/using_dispatch_test.go
@@ -266,6 +266,31 @@ end`
 	}
 }
 
+func TestDispatch_ReferencesThroughDispatchedImportNestedCall(t *testing.T) {
+	server, cleanup := setupDispatchServer(t)
+	defer cleanup()
+
+	callerSrc := `defmodule MyApp.PageController do
+  use MyAppWeb, :controller
+
+  def index(conn) do
+    render(meta: assign_defaults(conn))
+  end
+end`
+	indexFile(t, server.store, server.projectRoot, "lib/nested_page_controller.ex", callerSrc)
+
+	helpersURI := "file://" + filepath.Join(server.projectRoot, "lib/controller_helpers.ex")
+	server.docs.Set(helpersURI, controllerHelpersSrc)
+
+	locs := referencesAt(t, server, helpersURI, 1, 6)
+	for _, l := range locs {
+		if filepath.Base(string(l.URI)) == "nested_page_controller.ex" {
+			return
+		}
+	}
+	t.Fatalf("expected the nested call site in nested_page_controller.ex, got %d locations", len(locs))
+}
+
 func TestDispatch_CompletionUsesSelectedBody(t *testing.T) {
 	server, cleanup := setupDispatchServer(t)
 	defer cleanup()

--- a/internal/lsp/using_dispatch_test.go
+++ b/internal/lsp/using_dispatch_test.go
@@ -265,3 +265,146 @@ end`
 		t.Fatalf("expected the call site in page_controller.ex, got %d locations", len(locs))
 	}
 }
+
+func TestDispatch_CompletionUsesSelectedBody(t *testing.T) {
+	server, cleanup := setupDispatchServer(t)
+	defer cleanup()
+
+	uri := "file://" + filepath.Join(server.projectRoot, "lib/caller.ex")
+	server.docs.Set(uri, `defmodule MyApp.PageController do
+  use MyAppWeb, :controller
+
+  assign_d
+end`)
+
+	items := completionAt(t, server, uri, 3, 10)
+	if !hasCompletionItem(items, "assign_defaults") {
+		t.Fatal("expected completion from the selected dispatch body")
+	}
+
+	server.docs.Set(uri, `defmodule MyApp.PageController do
+  use MyAppWeb, :controller
+
+  for
+end`)
+	items = completionAt(t, server, uri, 3, 5)
+	if hasCompletionItem(items, "format_money") {
+		t.Fatal("completion leaked from a different dispatch body")
+	}
+}
+
+func TestDispatch_MergesAliasesFromSelectedBody(t *testing.T) {
+	server, cleanup := setupDispatchServer(t)
+	defer cleanup()
+
+	indexFile(t, server.store, server.projectRoot, "lib/router_helpers.ex", `defmodule MyApp.Router.Helpers do
+  def page_path(conn, action), do: {conn, action}
+end`)
+	indexFile(t, server.store, server.projectRoot, "lib/aliased_web.ex", `defmodule MyApp.AliasedWeb do
+  def controller do
+    quote do
+      alias MyApp.Router.Helpers, as: Routes
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which), do: apply(__MODULE__, which, [])
+end`)
+
+	src := `defmodule MyApp.PageController do
+  use MyApp.AliasedWeb, :controller
+
+  def index(conn), do: Routes.page_path(conn, :index)
+end`
+	if got := callerDefinition(t, server, src, 3, 31); len(got) == 0 {
+		t.Fatal("expected alias injected by selected dispatch body to resolve")
+	}
+}
+
+func TestDispatch_FollowsNestedDispatchOnSameModule(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	indexFile(t, server.store, server.projectRoot, "lib/nested_web.ex", `defmodule MyApp.NestedWeb do
+  def controller do
+    quote do
+      import MyApp.ControllerHelpers
+    end
+  end
+
+  def api_controller do
+    quote do
+      use MyApp.NestedWeb, :controller
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which), do: apply(__MODULE__, which, [])
+end`)
+	indexFile(t, server.store, server.projectRoot, "lib/controller_helpers.ex", controllerHelpersSrc)
+
+	src := `defmodule MyApp.APIController do
+  use MyApp.NestedWeb, :api_controller
+
+  def index(conn), do: assign_defaults(conn)
+end`
+	if got := callerDefinition(t, server, src, 3, 23); len(got) == 0 {
+		t.Fatal("expected nested use to retain its dispatch atom")
+	}
+}
+
+func TestDispatch_FollowsQuotedLocalHelper(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	indexFile(t, server.store, server.projectRoot, "lib/composed_web.ex", `defmodule MyApp.ComposedWeb do
+  def controller do
+    quote do
+      unquote(shared_helpers())
+    end
+  end
+
+  defp shared_helpers do
+    quote location: :keep do
+      import MyApp.ControllerHelpers
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which), do: apply(__MODULE__, which, [])
+end`)
+	indexFile(t, server.store, server.projectRoot, "lib/controller_helpers.ex", controllerHelpersSrc)
+
+	src := `defmodule MyApp.PageController do
+  use MyApp.ComposedWeb, :controller
+
+  def index(conn), do: assign_defaults(conn)
+end`
+	if got := callerDefinition(t, server, src, 3, 23); len(got) == 0 {
+		t.Fatal("expected dispatched quote to include its local quoted helper")
+	}
+}
+
+func TestDispatch_DoesNotReadTargetsFromSiblingModule(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	indexFile(t, server.store, server.projectRoot, "lib/multiple.ex", `defmodule MyAppWeb do
+  defmacro __using__(which) when is_atom(which), do: apply(__MODULE__, which, [])
+end
+
+defmodule SharedLib.OtherWeb do
+  def controller do
+    quote do
+      import MyApp.ControllerHelpers
+    end
+  end
+end`)
+	indexFile(t, server.store, server.projectRoot, "lib/controller_helpers.ex", controllerHelpersSrc)
+
+	src := `defmodule MyApp.PageController do
+  use MyAppWeb, :controller
+
+  def index(conn), do: assign_defaults(conn)
+end`
+	if got := callerDefinition(t, server, src, 3, 23); len(got) != 0 {
+		t.Fatal("dispatch target from a sibling module leaked into MyAppWeb")
+	}
+}

--- a/internal/lsp/using_dispatch_test.go
+++ b/internal/lsp/using_dispatch_test.go
@@ -1,0 +1,267 @@
+package lsp
+
+import (
+	"path/filepath"
+	"testing"
+
+	"go.lsp.dev/protocol"
+)
+
+// entrypointSrc mirrors the Phoenix-style atom dispatch entrypoint:
+//
+//	defmacro __using__(which) when is_atom(which), do: apply(__MODULE__, which, [])
+//
+// Each `def <name> do quote do ... end end` is a separate injection target,
+// selected by the atom the consumer passes to `use`.
+const dispatchEntrypointSrc = `defmodule MyAppWeb do
+  def controller do
+    quote do
+      import MyApp.ControllerHelpers
+
+      def render_page(conn), do: conn
+    end
+  end
+
+  def view do
+    quote do
+      import MyApp.ViewHelpers
+    end
+  end
+
+  def live_view(opts \\ []) do
+    quote do
+      import MyApp.LiveHelpers
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+
+  defmacro __using__([{which, opts}]) when is_atom(which) do
+    apply(__MODULE__, which, [List.wrap(opts)])
+  end
+end`
+
+const controllerHelpersSrc = `defmodule MyApp.ControllerHelpers do
+  def assign_defaults(conn), do: conn
+end`
+
+const viewHelpersSrc = `defmodule MyApp.ViewHelpers do
+  def format_money(amount), do: amount
+end`
+
+const liveHelpersSrc = `defmodule MyApp.LiveHelpers do
+  def assign_socket(socket), do: socket
+end`
+
+func setupDispatchServer(t *testing.T) (*Server, func()) {
+	t.Helper()
+	server, cleanup := setupTestServer(t)
+	indexFile(t, server.store, server.projectRoot, "lib/my_app_web.ex", dispatchEntrypointSrc)
+	indexFile(t, server.store, server.projectRoot, "lib/controller_helpers.ex", controllerHelpersSrc)
+	indexFile(t, server.store, server.projectRoot, "lib/view_helpers.ex", viewHelpersSrc)
+	indexFile(t, server.store, server.projectRoot, "lib/live_helpers.ex", liveHelpersSrc)
+	return server, cleanup
+}
+
+// callerDefinition indexes callerSrc and asks for the definition at line/col.
+func callerDefinition(t *testing.T, server *Server, callerSrc string, line, col uint32) []protocol.Location {
+	t.Helper()
+	callerURI := "file://" + filepath.Join(server.projectRoot, "lib/caller.ex")
+	server.docs.Set(callerURI, callerSrc)
+	return definitionAt(t, server, callerURI, line, col)
+}
+
+func TestDispatch_ResolvesImportFromDispatchedBlock(t *testing.T) {
+	server, cleanup := setupDispatchServer(t)
+	defer cleanup()
+
+	src := `defmodule MyApp.PageController do
+  use MyAppWeb, :controller
+
+  def index(conn) do
+    assign_defaults(conn)
+  end
+end`
+	// line 4, col 4 is on `assign_defaults`
+	if got := callerDefinition(t, server, src, 4, 4); len(got) == 0 {
+		t.Fatal("expected assign_defaults to resolve through `use MyAppWeb, :controller`")
+	}
+}
+
+func TestDispatch_ResolvesInlineDefFromDispatchedBlock(t *testing.T) {
+	server, cleanup := setupDispatchServer(t)
+	defer cleanup()
+
+	src := `defmodule MyApp.PageController do
+  use MyAppWeb, :controller
+
+  def index(conn) do
+    render_page(conn)
+  end
+end`
+	if got := callerDefinition(t, server, src, 4, 4); len(got) == 0 {
+		t.Fatal("expected render_page (inline def in the dispatched quote block) to resolve")
+	}
+}
+
+// The anti-fuzziness test: `:controller` must not pick up `:view`'s imports.
+func TestDispatch_DoesNotLeakAcrossDispatchTargets(t *testing.T) {
+	server, cleanup := setupDispatchServer(t)
+	defer cleanup()
+
+	src := `defmodule MyApp.PageController do
+  use MyAppWeb, :controller
+
+  def index(conn) do
+    format_money(conn)
+  end
+end`
+	if got := callerDefinition(t, server, src, 4, 4); len(got) != 0 {
+		t.Fatalf("format_money is imported only by `:view`; `:controller` must not see it, got %d results", len(got))
+	}
+}
+
+func TestDispatch_KeywordForm(t *testing.T) {
+	server, cleanup := setupDispatchServer(t)
+	defer cleanup()
+
+	src := `defmodule MyApp.PageLive do
+  use MyAppWeb, live_view: :no_sentry_context
+
+  def mount(socket) do
+    assign_socket(socket)
+  end
+end`
+	if got := callerDefinition(t, server, src, 4, 4); len(got) == 0 {
+		t.Fatal("expected assign_socket to resolve through `use MyAppWeb, live_view: :no_sentry_context`")
+	}
+}
+
+// Gate: the atom must name a def that exists in the entrypoint module.
+func TestDispatch_UnknownAtomResolvesNothing(t *testing.T) {
+	server, cleanup := setupDispatchServer(t)
+	defer cleanup()
+
+	src := `defmodule MyApp.PageController do
+  use MyAppWeb, :nonexistent
+
+  def index(conn) do
+    assign_defaults(conn)
+  end
+end`
+	if got := callerDefinition(t, server, src, 4, 4); len(got) != 0 {
+		t.Fatalf("`:nonexistent` names no def; expected no results, got %d", len(got))
+	}
+}
+
+// Gate: apply/3 must target __MODULE__, not some other module.
+func TestDispatch_RequiresSelfModuleApply(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	entrypoint := `defmodule MyAppWeb do
+  def controller do
+    quote do
+      import MyApp.ControllerHelpers
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(MyApp.Elsewhere, which, [])
+  end
+end`
+	indexFile(t, server.store, server.projectRoot, "lib/my_app_web.ex", entrypoint)
+	indexFile(t, server.store, server.projectRoot, "lib/controller_helpers.ex", controllerHelpersSrc)
+
+	src := `defmodule MyApp.PageController do
+  use MyAppWeb, :controller
+
+  def index(conn) do
+    assign_defaults(conn)
+  end
+end`
+	if got := callerDefinition(t, server, src, 4, 4); len(got) != 0 {
+		t.Fatalf("apply/3 targets another module; expected no results, got %d", len(got))
+	}
+}
+
+// Gate: the dispatched name must come from the __using__ clause's own parameter.
+func TestDispatch_RequiresUsingParameterAsName(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	entrypoint := `defmodule MyAppWeb do
+  def controller do
+    quote do
+      import MyApp.ControllerHelpers
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, :something_else, [])
+  end
+end`
+	indexFile(t, server.store, server.projectRoot, "lib/my_app_web.ex", entrypoint)
+	indexFile(t, server.store, server.projectRoot, "lib/controller_helpers.ex", controllerHelpersSrc)
+
+	src := `defmodule MyApp.PageController do
+  use MyAppWeb, :controller
+
+  def index(conn) do
+    assign_defaults(conn)
+  end
+end`
+	if got := callerDefinition(t, server, src, 4, 4); len(got) != 0 {
+		t.Fatalf("apply/3 does not dispatch on the __using__ parameter; expected no results, got %d", len(got))
+	}
+}
+
+// A plain `use Mod` on a dispatch module injects nothing: there is no atom.
+func TestDispatch_PlainUseInjectsNothing(t *testing.T) {
+	server, cleanup := setupDispatchServer(t)
+	defer cleanup()
+
+	src := `defmodule MyApp.PageController do
+  use MyAppWeb
+
+  def index(conn) do
+    assign_defaults(conn)
+  end
+end`
+	if got := callerDefinition(t, server, src, 4, 4); len(got) != 0 {
+		t.Fatalf("`use MyAppWeb` passes no atom; expected no results, got %d", len(got))
+	}
+}
+
+// References must reach call sites in modules that got the import through a
+// dispatch target, not just through a plain __using__ body.
+func TestDispatch_ReferencesThroughDispatchedImport(t *testing.T) {
+	server, cleanup := setupDispatchServer(t)
+	defer cleanup()
+
+	callerSrc := `defmodule MyApp.PageController do
+  use MyAppWeb, :controller
+
+  def index(conn) do
+    assign_defaults(conn)
+  end
+end`
+	indexFile(t, server.store, server.projectRoot, "lib/page_controller.ex", callerSrc)
+
+	helpersURI := "file://" + filepath.Join(server.projectRoot, "lib/controller_helpers.ex")
+	server.docs.Set(helpersURI, controllerHelpersSrc)
+
+	// line 1, col 6 is on `assign_defaults` in its definition
+	locs := referencesAt(t, server, helpersURI, 1, 6)
+	found := false
+	for _, l := range locs {
+		if filepath.Base(string(l.URI)) == "page_controller.ex" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected the call site in page_controller.ex, got %d locations", len(locs))
+	}
+}

--- a/internal/parser/parser_tokenized.go
+++ b/internal/parser/parser_tokenized.go
@@ -650,7 +650,13 @@ func parseTextFromTokens(path string, source []byte, tokens []Token) ([]Definiti
 			cm := currentModule()
 			if cm != "" && len(injectors) > 0 {
 				isStatementStart := i == 0 || tokens[i-1].Kind == TokEOL || tokens[i-1].Kind == TokComment
-				if isStatementStart {
+				// A parenthesized bare call can be nested inside another call,
+				// collection, or keyword value. It is still a candidate for a
+				// function imported by use/import, just like a statement-level call.
+				// Qualified and anonymous-function calls have a TokDot before the
+				// opening paren and therefore do not match this fast check.
+				isParenthesizedCall := i+1 < n && tokens[i+1].Kind == TokOpenParen
+				if isStatementStart || isParenthesizedCall {
 					name := tokenText(tok)
 					if !elixirKeyword[name] {
 						emit := false


### PR DESCRIPTION
  ## Summary

  - Resolve Phoenix-style atom dispatch such as `use MyAppWeb, :controller`
  - Preserve dispatch atoms and options through nested use chains
  - Support completion, aliases, callbacks, definitions, references, and hover
  - Follow quoted local helpers such as `unquote(html_helpers())`
  - Scope dispatch parsing correctly in multi-module files
  - Support quoted and tuple dispatch atoms