### PR TITLE
fix(lsp): count Position.character in UTF-16, as the protocol requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- **Positions were wrong on any line containing a non-ASCII character** — LSP counts `Position.character` in UTF-16 code units, and Dexter counted UTF-8 bytes. The two agree only while a line stays ASCII, so one accented character, bullet or emoji to the left of the cursor was enough to break go-to-definition, hover, references, completion and signature help. Worse, ranges were *emitted* in bytes too, so an editor applying a rename replaced a span shifted off the identifier and silently corrupted the source. Columns are now converted in both directions, on every client
+
 - **Module rename left the old file behind** — renaming a module from the file that defines it moved that file on disk while the editor still held the buffer, so the next save recreated the old file with the new module name and the project no longer compiled (`cannot define module X because it is currently being defined in ...`). Open files are now moved by the editor, through a `rename` resource operation in the reply, and the server touches neither path
 - **Grouped aliases were not renamed** — `alias Old.{A, B}` (and the `require`/`import` forms) kept pointing at the old module after a module rename, and in open buffers the shared prefix was rewritten once per member (`Old` → `NewNewNew...`)
 

--- a/internal/lsp/formatter.go
+++ b/internal/lsp/formatter.go
@@ -1031,11 +1031,21 @@ func (s *Server) publishFormatDiagnostic(uri protocol.DocumentURI, formatErr *Fo
 		col--
 	}
 
+	// Elixir reports the column as a 1-based count of characters, not bytes,
+	// so it has to become a byte offset before it can be re-encoded for the
+	// client. Counting code points is exactly what utf-32 means here.
+	diagCol := col
+	if text, ok := s.docs.GetOrLoad(string(uri)); ok {
+		lineText := lineAt(strings.Split(text, "\n"), int(line))
+		byteCol := WireToByteCol(lineText, int(col), EncodingUTF32)
+		diagCol = uint32(ByteToWireCol(lineText, byteCol, s.positionEncoding))
+	}
+
 	diagnostics := []protocol.Diagnostic{
 		{
 			Range: protocol.Range{
-				Start: protocol.Position{Line: line, Character: col},
-				End:   protocol.Position{Line: line, Character: col},
+				Start: protocol.Position{Line: line, Character: diagCol}, // position-encoding: converted
+				End:   protocol.Position{Line: line, Character: diagCol}, // position-encoding: converted
 			},
 			Severity: protocol.DiagnosticSeverityError,
 			Source:   "dexter",

--- a/internal/lsp/position_encoding.go
+++ b/internal/lsp/position_encoding.go
@@ -1,0 +1,181 @@
+package lsp
+
+import (
+	"unicode/utf8"
+
+	"go.lsp.dev/protocol"
+)
+
+// PositionEncoding is the unit both sides use to count Position.Character.
+//
+// The unit is a property of the protocol, not of the file. Elixir sources are
+// UTF-8 on disk either way; what changes here is only how a cursor column is
+// counted along a line.
+//
+// LSP made UTF-16 the default because it grew out of VS Code, whose strings
+// are UTF-16 internally, and that is what Dexter uses. LSP 3.17 added a way to
+// negotiate something else (the client offers general.positionEncodings and
+// the server echoes its pick in capabilities.positionEncoding), and Dexter
+// deliberately does not: a client only sends utf-8 if the server asks for it,
+// so declaring nothing means every client speaks UTF-16 and there is exactly
+// one path to get right. Negotiating utf-8 would skip the conversion below,
+// but that conversion costs ~25ns on an ASCII line and ~0.2ms on the largest
+// references reply we produce, which is under 1% of that request. The other
+// encodings stay implemented and tested so the choice can be revisited
+// cheaply.
+type PositionEncoding string
+
+const (
+	// EncodingUTF8 counts UTF-8 bytes. Dexter's internal representation, so
+	// this is the fast path: every conversion is the identity.
+	EncodingUTF8 PositionEncoding = "utf-8"
+	// EncodingUTF16 counts UTF-16 code units. The protocol default, and the
+	// only encoding a client is required to support.
+	EncodingUTF16 PositionEncoding = "utf-16"
+	// EncodingUTF32 counts Unicode code points. Some Emacs clients prefer it.
+	EncodingUTF32 PositionEncoding = "utf-32"
+)
+
+// runeUnits is how many units of enc one rune occupies.
+func runeUnits(r rune, enc PositionEncoding) int {
+	if enc == EncodingUTF16 && r > 0xFFFF {
+		// Astral code points are a surrogate pair: two UTF-16 units for one
+		// code point. This is the case the bottom-emoji bug turned on.
+		return 2
+	}
+	return 1
+}
+
+// isASCII reports whether line is pure ASCII, in which case every encoding
+// counts it identically and conversion is the identity.
+//
+// Almost every line of almost every file takes this path, so it is worth the
+// scan: it keeps the conversion off the hot path for ordinary code.
+func isASCII(line string) bool {
+	for i := 0; i < len(line); i++ {
+		if line[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
+// WireToByteCol converts a column as the client counts it into a UTF-8 byte
+// offset into line.
+//
+// Two rules keep this from corrupting text, both learned from other servers:
+//
+//   - A column past the end of the line clamps to the end rather than
+//     erroring. Clients do send these (a diagnostic at end of a truncated
+//     line, a cursor past the last character), and gopls treats it as a bug
+//     to reject them.
+//   - A column landing inside a multi-byte character snaps back to that
+//     character's first byte. Go, unlike Rust, does not panic when a string
+//     is sliced off a character boundary — it quietly yields mojibake — so
+//     nothing downstream would catch this for us.
+func WireToByteCol(line string, col int, enc PositionEncoding) int {
+	if col <= 0 {
+		return 0
+	}
+	if enc == EncodingUTF8 || isASCII(line) {
+		if col >= len(line) {
+			return len(line)
+		}
+		// Snap back to a boundary: a client that disagrees with us about the
+		// encoding can otherwise point us into the middle of a character.
+		for col > 0 && !utf8.RuneStart(line[col]) {
+			col--
+		}
+		return col
+	}
+
+	units := 0
+	for i, r := range line {
+		n := runeUnits(r, enc)
+		if units+n > col {
+			// col is at, or inside, this character. Either way its start is
+			// the only byte offset that keeps the string valid.
+			return i
+		}
+		units += n
+	}
+	return len(line)
+}
+
+// ByteToWireCol converts a UTF-8 byte offset into line into a column as the
+// client counts it. It is the inverse of WireToByteCol.
+//
+// This direction is the one that matters for correctness of edits: a range
+// the server emits in the wrong unit makes the editor replace the wrong span
+// of text, which silently corrupts the file on rename.
+func ByteToWireCol(line string, b int, enc PositionEncoding) int {
+	if b <= 0 {
+		return 0
+	}
+	if b > len(line) {
+		b = len(line)
+	}
+	if enc == EncodingUTF8 || isASCII(line) {
+		return b
+	}
+
+	units := 0
+	for i, r := range line {
+		if i >= b {
+			break
+		}
+		units += runeUnits(r, enc)
+	}
+	return units
+}
+
+// lineAt returns line n of lines, or "" when n is out of range. Conversion
+// treats a missing line as empty rather than failing: a stale position from
+// the client is not worth refusing a request over.
+func lineAt(lines []string, n int) string {
+	if n < 0 || n >= len(lines) {
+		return ""
+	}
+	return lines[n]
+}
+
+// inCol converts a column as the client sent it into a byte offset into
+// lines[n]. Every handler that reads Position.Character goes through here.
+func (s *Server) inCol(lines []string, n int, ch uint32) int {
+	if s.positionEncoding == EncodingUTF8 {
+		// Dexter's native unit: nothing to do, and no line lookup either.
+		return int(ch)
+	}
+	return WireToByteCol(lineAt(lines, n), int(ch), s.positionEncoding)
+}
+
+// outCol converts a byte offset into lines[n] into a column the client will
+// read correctly.
+//
+// This is the direction that decides whether an edit lands on the right
+// characters, so every Position the server emits must come from here, via
+// outPos or outPosLine below.
+func (s *Server) outCol(lines []string, n int, b int) uint32 {
+	if s.positionEncoding == EncodingUTF8 {
+		return uint32(b)
+	}
+	return uint32(ByteToWireCol(lineAt(lines, n), b, s.positionEncoding))
+}
+
+// outPos builds a Position on line n from a byte offset.
+func (s *Server) outPos(lines []string, n, byteCol int) protocol.Position {
+	return protocol.Position{Line: uint32(n), Character: s.outCol(lines, n, byteCol)}
+}
+
+// outPosLine builds a Position when only the one line's text is at hand,
+// which is the case for results pointing into a file other than the one the
+// request named (call hierarchy, cross-file rename edits).
+func (s *Server) outPosLine(line string, n, byteCol int) protocol.Position {
+	if s.positionEncoding == EncodingUTF8 {
+		return protocol.Position{Line: uint32(n), Character: uint32(byteCol)}
+	}
+	return protocol.Position{
+		Line:      uint32(n),
+		Character: uint32(ByteToWireCol(line, byteCol, s.positionEncoding)),
+	}
+}

--- a/internal/lsp/position_encoding_e2e_test.go
+++ b/internal/lsp/position_encoding_e2e_test.go
@@ -1,0 +1,168 @@
+package lsp
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	"go.lsp.dev/protocol"
+)
+
+// utf16Col is the column a UTF-16 client reports for the first occurrence of
+// needle in line — what Neovim, VS Code and the rest actually put on the wire.
+func utf16Col(line, needle string) uint32 {
+	i := strings.Index(line, needle)
+	if i < 0 {
+		return 0
+	}
+	return uint32(len(utf16.Encode([]rune(line[:i]))))
+}
+
+// byteCol is the same position counted in UTF-8 bytes, which is what Dexter
+// works in internally.
+func byteCol(line, needle string) uint32 {
+	i := strings.Index(line, needle)
+	if i < 0 {
+		return 0
+	}
+	return uint32(i)
+}
+
+// The caller line carries three 2-byte characters before the call, so a
+// UTF-16 client and a byte-counting server disagree by exactly three.
+const nonASCIISource = `defmodule MyApp.Prices do
+  alias MyApp.Money
+
+  def table do
+    %{"São Tomé and Príncipe" => Money.new(:EUR, "19.95")}
+  end
+end`
+
+const moneySource = `defmodule MyApp.Money do
+  def new(currency, amount), do: {currency, amount}
+end`
+
+func setupNonASCIIServer(t *testing.T, enc PositionEncoding) (*Server, string, string, func()) {
+	t.Helper()
+	server, cleanup := setupTestServer(t)
+	server.positionEncoding = enc
+
+	indexFile(t, server.store, server.projectRoot, "lib/money.ex", moneySource)
+	indexFile(t, server.store, server.projectRoot, "lib/prices.ex", nonASCIISource)
+
+	fileURI := "file://" + filepath.Join(server.projectRoot, "lib/prices.ex")
+	server.docs.Set(fileURI, nonASCIISource)
+
+	// Line 4 (0-based) is the one holding the accented characters.
+	line := strings.Split(nonASCIISource, "\n")[4]
+	return server, fileURI, line, cleanup
+}
+
+// TestDefinition_UTF16ClientOnNonASCIILine is the original bug: a client
+// counting UTF-16 units asks about a line with accented characters on it.
+// The server used to read that column as a byte offset, land three bytes
+// short of the call, and find nothing.
+func TestDefinition_UTF16ClientOnNonASCIILine(t *testing.T) {
+	server, fileURI, line, cleanup := setupNonASCIIServer(t, EncodingUTF16)
+	defer cleanup()
+
+	col := utf16Col(line, "Money")
+	if col == byteCol(line, "Money") {
+		t.Fatalf("test line must make the two encodings disagree; both are %d", col)
+	}
+
+	locs := definitionAt(t, server, fileURI, 4, col)
+	if len(locs) == 0 {
+		t.Fatalf("no definition at utf-16 column %d on %q", col, line)
+	}
+	if got := filepath.Base(uriToPath(locs[0].URI)); got != "money.ex" {
+		t.Errorf("resolved to %s, want money.ex", got)
+	}
+}
+
+// TestDefinition_UTF8ClientOnNonASCIILine covers the utf-8 branch, which
+// nothing selects today because Dexter does not negotiate. It is kept so the
+// branch stays honest if that changes: with utf-8 set, columns are byte
+// offsets and pass through untouched.
+func TestDefinition_UTF8ClientOnNonASCIILine(t *testing.T) {
+	server, fileURI, line, cleanup := setupNonASCIIServer(t, EncodingUTF8)
+	defer cleanup()
+
+	locs := definitionAt(t, server, fileURI, 4, byteCol(line, "Money"))
+	if len(locs) == 0 {
+		t.Fatalf("no definition at byte column %d on %q", byteCol(line, "Money"), line)
+	}
+	if got := filepath.Base(uriToPath(locs[0].URI)); got != "money.ex" {
+		t.Errorf("resolved to %s, want money.ex", got)
+	}
+}
+
+// TestRenameEdit_UTF16RangesLandOnTheRightText is the case that damaged
+// files. The server used to answer with byte columns whatever the client
+// counted in; an editor applying those as UTF-16 replaced a span shifted off
+// the identifier, quietly corrupting the line.
+//
+// Applying the reply exactly as a UTF-16 client would is the only way to
+// catch that, so that is what this asserts.
+func TestRenameEdit_UTF16RangesLandOnTheRightText(t *testing.T) {
+	server, fileURI, line, cleanup := setupNonASCIIServer(t, EncodingUTF16)
+	defer cleanup()
+
+	edit, err := server.RenameEdit(context.Background(), &protocol.RenameParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentURI(fileURI)},
+			Position:     protocol.Position{Line: 4, Character: utf16Col(line, "Money")},
+		},
+		NewName: "Cash",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edit == nil {
+		t.Fatal("rename produced no edit")
+	}
+
+	edits := editsForURI(edit, fileURI)
+	if len(edits) == 0 {
+		t.Fatalf("no edits for %s", fileURI)
+	}
+
+	for _, e := range edits {
+		if e.Range.Start.Line != 4 {
+			continue
+		}
+		got := sliceUTF16(line, e.Range.Start.Character, e.Range.End.Character)
+		if got != "Money" {
+			t.Errorf("edit range [%d,%d) selects %q as a utf-16 client reads it, want %q\n  line: %s",
+				e.Range.Start.Character, e.Range.End.Character, got, "Money", line)
+		}
+	}
+}
+
+// sliceUTF16 extracts [start,end) counted in UTF-16 units, which is how the
+// editor will read the range the server sent.
+func sliceUTF16(line string, start, end uint32) string {
+	units := utf16.Encode([]rune(line))
+	if int(start) > len(units) {
+		start = uint32(len(units))
+	}
+	if int(end) > len(units) {
+		end = uint32(len(units))
+	}
+	return string(utf16.Decode(units[start:end]))
+}
+
+func editsForURI(edit *WorkspaceEdit, fileURI string) []protocol.TextEdit {
+	if e, ok := edit.Changes[protocol.DocumentURI(fileURI)]; ok {
+		return e
+	}
+	for _, dc := range edit.DocumentChanges {
+		tde, ok := dc.(TextDocumentEdit)
+		if ok && string(tde.TextDocument.URI) == fileURI {
+			return tde.Edits
+		}
+	}
+	return nil
+}

--- a/internal/lsp/position_encoding_guard_test.go
+++ b/internal/lsp/position_encoding_guard_test.go
@@ -1,0 +1,73 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// exemptFromPositionGuard are the files allowed to build a protocol.Position
+// by hand. Only the conversion helpers themselves qualify.
+var exemptFromPositionGuard = map[string]bool{
+	"position_encoding.go": true,
+}
+
+// TestNoUnconvertedPositions fails when a protocol.Position is built with a
+// column that did not come through the position-encoding funnels.
+//
+// The compiler cannot catch this: a raw protocol.Position{...} compiles
+// perfectly well and is wrong only on lines containing non-ASCII, which no
+// ordinary test exercises. A miss here is not a crash but a silently
+// misplaced edit — on rename, a corrupted file — so the check has to be
+// mechanical rather than left to review.
+//
+// To add a legitimate exception, end the line with the marker comment below
+// and say in the surrounding code why the column is already correct.
+func TestNoUnconvertedPositions(t *testing.T) {
+	const marker = "// position-encoding: converted"
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	var offenders []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || filepath.Ext(name) != ".go" {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") || exemptFromPositionGuard[name] {
+			continue
+		}
+		data, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			if !strings.Contains(line, "protocol.Position{") {
+				continue
+			}
+			trimmed := strings.TrimSpace(line)
+			// A column of zero is the start of the line in every encoding.
+			if strings.Contains(trimmed, "Character: 0}") || strings.Contains(trimmed, "Character: 0,") {
+				continue
+			}
+			if strings.Contains(trimmed, marker) {
+				continue
+			}
+			offenders = append(offenders, name+":"+strconv.Itoa(i+1)+": "+trimmed)
+		}
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("protocol.Position built without a position-encoding conversion.\n"+
+			"Use s.outPos (when the file's lines are at hand) or s.outPosLine\n"+
+			"(when only one line is), so the column reaches the client in the\n"+
+			"unit the protocol expects. If the column is already converted, end\n"+
+			"the line with %q.\n\n%s",
+			marker, strings.Join(offenders, "\n"))
+	}
+}

--- a/internal/lsp/position_encoding_test.go
+++ b/internal/lsp/position_encoding_test.go
@@ -1,0 +1,150 @@
+package lsp
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestWireToByteCol(t *testing.T) {
+	// "🥺" is the bottom emoji from the rust-analyzer bug: 4 UTF-8 bytes,
+	// 2 UTF-16 units, 1 code point. Every unit disagrees, which is the point.
+	tests := []struct {
+		name string
+		line string
+		col  int
+		enc  PositionEncoding
+		want int
+	}{
+		{"ascii utf-16 is identity", "def foo do", 4, EncodingUTF16, 4},
+		{"ascii utf-8 is identity", "def foo do", 4, EncodingUTF8, 4},
+		{"negative clamps to zero", "abc", -5, EncodingUTF16, 0},
+		{"zero is zero", "abc", 0, EncodingUTF16, 0},
+
+		// é is 2 bytes, 1 utf-16 unit -> drift of 1 per character.
+		{"after e-acute", "\"Réunion\" => Money", 13, EncodingUTF16, 14},
+		// ã é í: three 2-byte characters -> drift of 3.
+		{"after three accents", "\"São Tomé and Príncipe\" => M", 26, EncodingUTF16, 29},
+		// • is 3 bytes, 1 utf-16 unit -> drift of 2.
+		{"after bullet", "• Money", 2, EncodingUTF16, 4},
+		// 🥺 is 4 bytes, 2 utf-16 units -> drift of 2.
+		{"after bottom emoji", "🥺 Money", 3, EncodingUTF16, 5},
+
+		// utf-32 counts code points, so an astral char costs 1, not 2.
+		{"utf-32 after emoji", "🥺 Money", 2, EncodingUTF32, 5},
+		{"utf-32 after bullet", "• Money", 2, EncodingUTF32, 4},
+
+		// Clamping: past the end of the line is legal input.
+		{"past end clamps", "abc", 99, EncodingUTF16, 3},
+		{"past end clamps utf-8", "abc", 99, EncodingUTF8, 3},
+		{"past end with multibyte clamps", "é", 99, EncodingUTF16, 2},
+		{"empty line", "", 5, EncodingUTF16, 0},
+
+		// The corrupting case: a column landing inside a character must snap
+		// back to its first byte, never into the middle of it.
+		{"inside surrogate pair snaps to start", "🥺x", 1, EncodingUTF16, 0},
+		{"utf-8 col inside emoji snaps back", "🥺x", 2, EncodingUTF8, 0},
+		{"utf-8 col inside 2-byte char snaps back", "éx", 1, EncodingUTF8, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WireToByteCol(tt.line, tt.col, tt.enc)
+			if got != tt.want {
+				t.Errorf("WireToByteCol(%q, %d, %s) = %d, want %d", tt.line, tt.col, tt.enc, got, tt.want)
+			}
+			// Whatever we return must be a valid slice point, always.
+			if got < 0 || got > len(tt.line) {
+				t.Fatalf("offset %d out of range for %q", got, tt.line)
+			}
+			if got < len(tt.line) && !utf8.RuneStart(tt.line[got]) {
+				t.Errorf("offset %d is not a character boundary in %q", got, tt.line)
+			}
+		})
+	}
+}
+
+func TestByteToWireCol(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		b    int
+		enc  PositionEncoding
+		want int
+	}{
+		{"ascii identity", "def foo", 4, EncodingUTF16, 4},
+		{"utf-8 identity", "🥺 Money", 5, EncodingUTF8, 5},
+		{"negative clamps", "abc", -1, EncodingUTF16, 0},
+		{"after e-acute", "\"Réunion\" => Money", 14, EncodingUTF16, 13},
+		{"after three accents", "\"São Tomé and Príncipe\" => M", 29, EncodingUTF16, 26},
+		{"after bullet", "• Money", 4, EncodingUTF16, 2},
+		{"after bottom emoji", "🥺 Money", 5, EncodingUTF16, 3},
+		{"utf-32 after emoji", "🥺 Money", 5, EncodingUTF32, 2},
+		{"past end clamps", "abc", 99, EncodingUTF16, 3},
+		{"empty line", "", 3, EncodingUTF16, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ByteToWireCol(tt.line, tt.b, tt.enc); got != tt.want {
+				t.Errorf("ByteToWireCol(%q, %d, %s) = %d, want %d", tt.line, tt.b, tt.enc, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPositionEncodingRoundTrip is the property that makes edits safe: a byte
+// offset sent to the client and read back must land where it started.
+// Rename correctness depends on it directly.
+func TestPositionEncodingRoundTrip(t *testing.T) {
+	lines := []string{
+		"def render(conn, params) do",
+		"\"São Tomé and Príncipe\" => Money.new(:EUR, \"19.95\")",
+		"• *Payroll run:* #{SlackHelpers.link(url)}",
+		"🥺🥺🥺 def foo do",
+		"",
+		"é",
+		strings.Repeat("ü", 50) + " Money.new()",
+		"mixed 🥺 é • ascii tail",
+	}
+	for _, enc := range []PositionEncoding{EncodingUTF8, EncodingUTF16, EncodingUTF32} {
+		for _, line := range lines {
+			// Every character boundary must survive a round trip.
+			for b := range line {
+				if !utf8.RuneStart(line[b]) {
+					continue
+				}
+				wire := ByteToWireCol(line, b, enc)
+				back := WireToByteCol(line, wire, enc)
+				if back != b {
+					t.Errorf("enc=%s line=%q: byte %d -> wire %d -> byte %d", enc, line, b, wire, back)
+				}
+			}
+			// The end of the line is a valid position too.
+			wire := ByteToWireCol(line, len(line), enc)
+			if back := WireToByteCol(line, wire, enc); back != len(line) {
+				t.Errorf("enc=%s line=%q: end %d -> wire %d -> byte %d", enc, line, len(line), wire, back)
+			}
+		}
+	}
+}
+
+// TestWireToByteColNeverSplitsCharacter feeds every column a hostile or
+// out-of-sync client could send and asserts we never hand back an offset that
+// would slice a character in half. Go yields mojibake rather than panicking
+// there, so this is the only thing standing between a bad column and a
+// corrupted buffer.
+func TestWireToByteColNeverSplitsCharacter(t *testing.T) {
+	lines := []string{"🥺 Money", "é • 🥺 x", "São Tomé", "plain ascii"}
+	for _, enc := range []PositionEncoding{EncodingUTF8, EncodingUTF16, EncodingUTF32} {
+		for _, line := range lines {
+			for col := -3; col < len(line)+5; col++ {
+				got := WireToByteCol(line, col, enc)
+				if got < 0 || got > len(line) {
+					t.Fatalf("enc=%s line=%q col=%d: offset %d out of range", enc, line, col, got)
+				}
+				if got < len(line) && !utf8.RuneStart(line[got]) {
+					t.Errorf("enc=%s line=%q col=%d: offset %d splits a character", enc, line, col, got)
+				}
+			}
+		}
+	}
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -102,6 +102,12 @@ type Server struct {
 	showDocumentSupported  bool          // client supports window/showDocument (LSP 3.16+)
 	renameFileOpsSupported bool          // client applies rename resource operations in a WorkspaceEdit
 	snippetSupport         bool          // client supports snippet insert text in completions
+	// positionEncoding is the unit the client counts Position.Character in.
+	// Dexter never negotiates, so this is always UTF-16 in practice — see the
+	// type's doc comment for why — and columns are converted at the edges by
+	// inCol/outCol. It stays a field rather than a constant so a future
+	// negotiation can set it without touching every call site.
+	positionEncoding PositionEncoding
 
 	reindexing sync.Mutex // serializes concurrent backgroundReindex calls
 
@@ -141,6 +147,9 @@ func NewServer(s *store.Store, projectRoot string) *Server {
 		erlangRuntimeCache: make(map[string]*erlangRuntimeCache),
 		usingCache:         make(map[string]*usingCacheEntry),
 		depsCache:          make(map[string]bool),
+		// What every client sends when the server declares no encoding, which
+		// Dexter does not.
+		positionEncoding: EncodingUTF16,
 	}
 }
 
@@ -838,7 +847,7 @@ func (s *Server) Definition(ctx context.Context, params *protocol.DefinitionPara
 
 	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 
 	if lineNum >= len(lines) {
 		return nil, nil
@@ -1510,7 +1519,7 @@ func (s *Server) CodeAction(ctx context.Context, params *protocol.CodeActionPara
 
 	// Find the full dotted expression at the cursor so that "DocuSign.Client.request"
 	// gives us the complete module reference, not just the segment under the cursor.
-	col := int(params.Range.Start.Character)
+	col := s.inCol(lines, lineNum, params.Range.Start.Character)
 	tf := s.docs.GetTokenizedFile(docURI)
 	if tf == nil {
 		tf = NewTokenizedFile(text)
@@ -1562,8 +1571,8 @@ func (s *Server) CodeAction(ctx context.Context, params *protocol.CodeActionPara
 			// Replace the qualified module reference with the short name
 			edits = append(edits, protocol.TextEdit{
 				Range: protocol.Range{
-					Start: protocol.Position{Line: uint32(lineNum), Character: uint32(exprStart)},
-					End:   protocol.Position{Line: uint32(lineNum), Character: uint32(exprStart + len(moduleRef))},
+					Start: s.outPos(lines, lineNum, exprStart),
+					End:   s.outPos(lines, lineNum, exprStart+len(moduleRef)),
 				},
 				NewText: lastSegment,
 			})
@@ -1676,7 +1685,7 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 
 	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 
 	if lineNum >= len(lines) {
 		return nil, nil
@@ -1736,8 +1745,8 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 	// Range covering the already-typed prefix through cursor — used for
 	// textEdit on module items so the editor replaces rather than appends.
 	prefixRange := protocol.Range{
-		Start: protocol.Position{Line: uint32(lineNum), Character: uint32(prefixStartCol)},
-		End:   protocol.Position{Line: uint32(lineNum), Character: uint32(col)},
+		Start: s.outPos(lines, lineNum, prefixStartCol),
+		End:   s.outPos(lines, lineNum, col),
 	}
 	inPipe := IsPipeContext(lines[lineNum], prefixStartCol)
 
@@ -2942,7 +2951,7 @@ func (s *Server) Declaration(ctx context.Context, params *protocol.DeclarationPa
 	path := uriToPath(params.TextDocument.URI)
 	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 
 	if lineNum >= len(lines) {
 		return nil, nil
@@ -3166,8 +3175,9 @@ func (s *Server) DocumentHighlight(ctx context.Context, params *protocol.Documen
 		return nil, nil
 	}
 
+	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 
 	tree, src, release, hasTree := s.docs.GetTree(docURI)
 	if !hasTree {
@@ -3182,8 +3192,8 @@ func (s *Server) DocumentHighlight(ctx context.Context, params *protocol.Documen
 		for _, occ := range occs {
 			highlights = append(highlights, protocol.DocumentHighlight{
 				Range: protocol.Range{
-					Start: protocol.Position{Line: uint32(occ.Line), Character: uint32(occ.StartCol)},
-					End:   protocol.Position{Line: uint32(occ.Line), Character: uint32(occ.EndCol)},
+					Start: s.outPos(lines, int(occ.Line), int(occ.StartCol)),
+					End:   s.outPos(lines, int(occ.Line), int(occ.EndCol)),
 				},
 				Kind: protocol.DocumentHighlightKindText,
 			})
@@ -3218,8 +3228,8 @@ func (s *Server) DocumentHighlight(ctx context.Context, params *protocol.Documen
 	for _, occ := range occs {
 		highlights = append(highlights, protocol.DocumentHighlight{
 			Range: protocol.Range{
-				Start: protocol.Position{Line: uint32(occ.Line), Character: uint32(occ.StartCol)},
-				End:   protocol.Position{Line: uint32(occ.Line), Character: uint32(occ.EndCol)},
+				Start: s.outPos(lines, int(occ.Line), int(occ.StartCol)),
+				End:   s.outPos(lines, int(occ.Line), int(occ.EndCol)),
 			},
 			Kind: protocol.DocumentHighlightKindText,
 		})
@@ -3339,7 +3349,7 @@ func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 				continue
 			}
 			lineIdx := tok.Line - 1
-			endPos := protocol.Position{Line: uint32(lineIdx), Character: uint32(lineEndChar(lineIdx))}
+			endPos := s.outPos(lines, lineIdx, lineEndChar(lineIdx))
 
 			prevDepth := depth
 			parser.TrackBlockDepth(tok.Kind, &depth)
@@ -3397,8 +3407,8 @@ func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 						End:   protocol.Position{Line: uint32(lastLine), Character: 0},
 					},
 					SelectionRange: protocol.Range{
-						Start: protocol.Position{Line: uint32(lineIdx), Character: uint32(nameCol)},
-						End:   protocol.Position{Line: uint32(lineIdx), Character: uint32(nameCol + len(name))},
+						Start: s.outPos(lines, lineIdx, nameCol),
+						End:   s.outPos(lines, lineIdx, nameCol+len(name)),
 					},
 				},
 				module:    curMod,
@@ -3435,7 +3445,7 @@ func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 
 			_, nextPos, hasDoBlock := parser.ScanForwardToBlockDo(tokens, n, j)
 
-			rangeEnd := protocol.Position{Line: uint32(lineIdx), Character: uint32(lineEndChar(lineIdx))}
+			rangeEnd := s.outPos(lines, lineIdx, lineEndChar(lineIdx))
 			if hasDoBlock {
 				rangeEnd = protocol.Position{Line: uint32(lastLine), Character: 0}
 			}
@@ -3451,8 +3461,8 @@ func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 						End:   rangeEnd,
 					},
 					SelectionRange: protocol.Range{
-						Start: protocol.Position{Line: uint32(lineIdx), Character: uint32(nameCol)},
-						End:   protocol.Position{Line: uint32(lineIdx), Character: uint32(nameCol + len(funcName))},
+						Start: s.outPos(lines, lineIdx, nameCol),
+						End:   s.outPos(lines, lineIdx, nameCol+len(funcName)),
 					},
 				},
 				module:    curMod,
@@ -3482,11 +3492,11 @@ func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 					Kind:   defKindToSymbolKind("defstruct"),
 					Range: protocol.Range{
 						Start: protocol.Position{Line: uint32(lineIdx), Character: 0},
-						End:   protocol.Position{Line: uint32(lineIdx), Character: uint32(lineEndChar(lineIdx))},
+						End:   s.outPos(lines, lineIdx, lineEndChar(lineIdx)),
 					},
 					SelectionRange: protocol.Range{
-						Start: protocol.Position{Line: uint32(lineIdx), Character: uint32(indent)},
-						End:   protocol.Position{Line: uint32(lineIdx), Character: uint32(indent + 9)},
+						Start: s.outPos(lines, lineIdx, indent),
+						End:   s.outPos(lines, lineIdx, indent+9),
 					},
 				},
 				module:    curMod,
@@ -3510,11 +3520,11 @@ func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 					Kind:   defKindToSymbolKind("defexception"),
 					Range: protocol.Range{
 						Start: protocol.Position{Line: uint32(lineIdx), Character: 0},
-						End:   protocol.Position{Line: uint32(lineIdx), Character: uint32(lineEndChar(lineIdx))},
+						End:   s.outPos(lines, lineIdx, lineEndChar(lineIdx)),
 					},
 					SelectionRange: protocol.Range{
-						Start: protocol.Position{Line: uint32(lineIdx), Character: uint32(indent)},
-						End:   protocol.Position{Line: uint32(lineIdx), Character: uint32(indent + 12)},
+						Start: s.outPos(lines, lineIdx, indent),
+						End:   s.outPos(lines, lineIdx, indent+12),
 					},
 				},
 				module:    curMod,
@@ -3560,11 +3570,11 @@ func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 					Kind:   defKindToSymbolKind(kind),
 					Range: protocol.Range{
 						Start: protocol.Position{Line: uint32(lineIdx), Character: 0},
-						End:   protocol.Position{Line: uint32(lineIdx), Character: uint32(lineEndChar(lineIdx))},
+						End:   s.outPos(lines, lineIdx, lineEndChar(lineIdx)),
 					},
 					SelectionRange: protocol.Range{
-						Start: protocol.Position{Line: uint32(lineIdx), Character: uint32(nameCol)},
-						End:   protocol.Position{Line: uint32(lineIdx), Character: uint32(nameCol + len(name))},
+						Start: s.outPos(lines, lineIdx, nameCol),
+						End:   s.outPos(lines, lineIdx, nameCol+len(name)),
 					},
 				},
 				module:    curMod,
@@ -3608,11 +3618,11 @@ func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 					Kind:   defKindToSymbolKind(kind),
 					Range: protocol.Range{
 						Start: protocol.Position{Line: uint32(lineIdx), Character: 0},
-						End:   protocol.Position{Line: uint32(lineIdx), Character: uint32(lineEndChar(lineIdx))},
+						End:   s.outPos(lines, lineIdx, lineEndChar(lineIdx)),
 					},
 					SelectionRange: protocol.Range{
-						Start: protocol.Position{Line: uint32(lineIdx), Character: uint32(nameCol)},
-						End:   protocol.Position{Line: uint32(lineIdx), Character: uint32(nameCol + len(name))},
+						Start: s.outPos(lines, lineIdx, nameCol),
+						End:   s.outPos(lines, lineIdx, nameCol+len(name)),
 					},
 				},
 				module:    curMod,
@@ -3668,8 +3678,8 @@ func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 						End:   protocol.Position{Line: uint32(lastLine), Character: 0},
 					},
 					SelectionRange: protocol.Range{
-						Start: protocol.Position{Line: uint32(lineIdx), Character: uint32(indent)},
-						End:   protocol.Position{Line: uint32(lineIdx), Character: uint32(indent + len(macroName))},
+						Start: s.outPos(lines, lineIdx, indent),
+						End:   s.outPos(lines, lineIdx, indent+len(macroName)),
 					},
 				},
 				module:    curMod,
@@ -3893,7 +3903,7 @@ func (s *Server) Hover(ctx context.Context, params *protocol.HoverParams) (*prot
 
 	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 
 	if lineNum >= len(lines) {
 		return nil, nil
@@ -4008,7 +4018,7 @@ func (s *Server) Implementation(ctx context.Context, params *protocol.Implementa
 
 	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 
 	if lineNum >= len(lines) {
 		return nil, nil
@@ -4075,7 +4085,7 @@ func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRena
 
 	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 	if lineNum >= len(lines) {
 		return nil, nil
 	}
@@ -4097,14 +4107,14 @@ func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRena
 				for _, occ := range occs {
 					if occ.Line == uint(lineNum) && uint(col) >= occ.StartCol && uint(col) < occ.EndCol {
 						return &protocol.Range{
-							Start: protocol.Position{Line: uint32(occ.Line), Character: uint32(occ.StartCol)},
-							End:   protocol.Position{Line: uint32(occ.Line), Character: uint32(occ.EndCol)},
+							Start: s.outPos(lines, int(occ.Line), int(occ.StartCol)),
+							End:   s.outPos(lines, int(occ.Line), int(occ.EndCol)),
 						}, nil
 					}
 				}
 				return &protocol.Range{
-					Start: protocol.Position{Line: uint32(occs[0].Line), Character: uint32(occs[0].StartCol)},
-					End:   protocol.Position{Line: uint32(occs[0].Line), Character: uint32(occs[0].EndCol)},
+					Start: s.outPos(lines, int(occs[0].Line), int(occs[0].StartCol)),
+					End:   s.outPos(lines, int(occs[0].Line), int(occs[0].EndCol)),
 				}, nil
 			}
 		}
@@ -4124,8 +4134,8 @@ func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRena
 			if resolved, ok := aliases[moduleRef]; ok && moduleLastSegment(resolved) != moduleRef {
 				// File-local alias rename: find all occurrences in this file
 				return &protocol.Range{
-					Start: protocol.Position{Line: uint32(lineNum), Character: uint32(exprStart)},
-					End:   protocol.Position{Line: uint32(lineNum), Character: uint32(exprStart + len(moduleRef))},
+					Start: s.outPos(lines, lineNum, exprStart),
+					End:   s.outPos(lines, lineNum, exprStart+len(moduleRef)),
 				}, nil
 			}
 		}
@@ -4192,8 +4202,8 @@ func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRena
 			if tokenOffset >= 0 {
 				tokenStart := exprStart + tokenOffset
 				return &protocol.Range{
-					Start: protocol.Position{Line: uint32(lineNum), Character: uint32(tokenStart)},
-					End:   protocol.Position{Line: uint32(lineNum), Character: uint32(tokenStart + len(tokenName))},
+					Start: s.outPos(lines, lineNum, tokenStart),
+					End:   s.outPos(lines, lineNum, tokenStart+len(tokenName)),
 				}, nil
 			}
 		}
@@ -4220,7 +4230,7 @@ func (s *Server) References(ctx context.Context, params *protocol.ReferenceParam
 
 	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 
 	if lineNum >= len(lines) {
 		s.debugf("References: line %d out of range (total %d)", lineNum, len(lines))
@@ -4297,8 +4307,8 @@ func (s *Server) References(ctx context.Context, params *protocol.ReferenceParam
 					locations = append(locations, protocol.Location{
 						URI: params.TextDocument.URI,
 						Range: protocol.Range{
-							Start: protocol.Position{Line: uint32(occ.Line), Character: uint32(occ.StartCol)},
-							End:   protocol.Position{Line: uint32(occ.Line), Character: uint32(occ.EndCol)},
+							Start: s.outPos(lines, int(occ.Line), int(occ.StartCol)),
+							End:   s.outPos(lines, int(occ.Line), int(occ.EndCol)),
 						},
 					})
 				}
@@ -4490,7 +4500,7 @@ func (s *Server) RenameEdit(ctx context.Context, params *protocol.RenameParams) 
 
 	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 	if lineNum >= len(lines) {
 		return nil, nil
 	}
@@ -4515,8 +4525,8 @@ func (s *Server) RenameEdit(ctx context.Context, params *protocol.RenameParams) 
 				for _, occ := range occs {
 					changes[protocol.DocumentURI(docURI)] = append(changes[protocol.DocumentURI(docURI)], protocol.TextEdit{
 						Range: protocol.Range{
-							Start: protocol.Position{Line: uint32(occ.Line), Character: uint32(occ.StartCol)},
-							End:   protocol.Position{Line: uint32(occ.Line), Character: uint32(occ.EndCol)},
+							Start: s.outPos(lines, int(occ.Line), int(occ.StartCol)),
+							End:   s.outPos(lines, int(occ.Line), int(occ.EndCol)),
 						},
 						NewText: params.NewName,
 					})
@@ -4551,8 +4561,8 @@ func (s *Server) RenameEdit(ctx context.Context, params *protocol.RenameParams) 
 						}
 						changes[fileURI] = append(changes[fileURI], protocol.TextEdit{
 							Range: protocol.Range{
-								Start: protocol.Position{Line: uint32(i), Character: uint32(col)},
-								End:   protocol.Position{Line: uint32(i), Character: uint32(col + len(moduleRef))},
+								Start: s.outPos(lines, i, col),
+								End:   s.outPos(lines, i, col+len(moduleRef)),
 							},
 							NewText: params.NewName,
 						})
@@ -4773,7 +4783,7 @@ func (s *Server) renameFunctionEdits(module, functionName, newName string) (*Wor
 					edit.Changes[fileURI] = append(edit.Changes[fileURI], protocol.TextEdit{
 						Range: protocol.Range{
 							Start: protocol.Position{Line: uint32(spanStart), Character: 0},
-							End:   protocol.Position{Line: uint32(spanEnd - 1), Character: uint32(len(fileLines[spanEnd-1]))},
+							End:   s.outPos(fileLines, spanEnd-1, len(fileLines[spanEnd-1])),
 						},
 						NewText: strings.Join(updatedSpan, "\n"),
 					})
@@ -5273,8 +5283,8 @@ func (mr *moduleRename) applyEdits(fileCache map[string]moduleFileInfo, movedFil
 					claimed[es.line] = append(claimed[es.line], e)
 					openChanges[fileURI] = append(openChanges[fileURI], protocol.TextEdit{
 						Range: protocol.Range{
-							Start: protocol.Position{Line: uint32(es.line - 1), Character: uint32(e.col)},
-							End:   protocol.Position{Line: uint32(es.line - 1), Character: uint32(e.col + e.length)},
+							Start: mr.server.outPos(fi.lines, es.line-1, e.col),
+							End:   mr.server.outPos(fi.lines, es.line-1, e.col+e.length),
 						},
 						NewText: e.newToken,
 					})
@@ -5469,8 +5479,8 @@ func (s *Server) buildTextEdits(sites []renameSite, oldToken, newToken string) *
 				for _, col := range cols {
 					openChanges[fileURI] = append(openChanges[fileURI], protocol.TextEdit{
 						Range: protocol.Range{
-							Start: protocol.Position{Line: uint32(site.line - 1), Character: uint32(col)},
-							End:   protocol.Position{Line: uint32(site.line - 1), Character: uint32(col + len(oldToken))},
+							Start: s.outPos(fi.lines, site.line-1, col),
+							End:   s.outPos(fi.lines, site.line-1, col+len(oldToken)),
 						},
 						NewText: newToken,
 					})
@@ -5656,8 +5666,9 @@ func (s *Server) SignatureHelp(ctx context.Context, params *protocol.SignatureHe
 		return nil, nil
 	}
 
+	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 
 	// Get cached tokens for efficient multi-query operations
 	tf := s.docs.GetTokenizedFile(docURI)
@@ -5677,7 +5688,6 @@ func (s *Server) SignatureHelp(ctx context.Context, params *protocol.SignatureHe
 
 	aliases := tf.ExtractAliasesInScope(lineNum)
 	s.mergeAliasesFromUseTokenized(tf, aliases)
-	lines := strings.Split(text, "\n")
 
 	// Resolve the function to a store lookup result
 	var result *store.LookupResult
@@ -5825,7 +5835,7 @@ func (s *Server) TypeDefinition(ctx context.Context, params *protocol.TypeDefini
 
 	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 	if lineNum >= len(lines) {
 		return nil, nil
 	}
@@ -5898,7 +5908,7 @@ func (s *Server) PrepareCallHierarchy(ctx context.Context, params *protocol.Call
 
 	lines := strings.Split(text, "\n")
 	lineNum := int(params.Position.Line)
-	col := int(params.Position.Character)
+	col := s.inCol(lines, lineNum, params.Position.Character)
 	if lineNum >= len(lines) {
 		return nil, nil
 	}
@@ -5932,10 +5942,9 @@ func (s *Server) PrepareCallHierarchy(ctx context.Context, params *protocol.Call
 
 	r := defResults[0]
 	nameCol := 0
-	if defLine, ok := s.getFileLine(r.FilePath, r.Line); ok {
-		if col := findTokenColumn(defLine, functionName); col >= 0 {
-			nameCol = col
-		}
+	defLine, _ := s.getFileLine(r.FilePath, r.Line)
+	if col := findTokenColumn(defLine, functionName); col >= 0 {
+		nameCol = col
 	}
 
 	item := protocol.CallHierarchyItem{
@@ -5945,8 +5954,8 @@ func (s *Server) PrepareCallHierarchy(ctx context.Context, params *protocol.Call
 		URI:    protocol.DocumentURI(uri.File(r.FilePath)),
 		Range:  lineRange(r.Line - 1),
 		SelectionRange: protocol.Range{
-			Start: protocol.Position{Line: uint32(r.Line - 1), Character: uint32(nameCol)},
-			End:   protocol.Position{Line: uint32(r.Line - 1), Character: uint32(nameCol + len(functionName))},
+			Start: s.outPosLine(defLine, r.Line-1, nameCol),
+			End:   s.outPosLine(defLine, r.Line-1, nameCol+len(functionName)),
 		},
 		Data: map[string]string{"module": fullModule, "function": functionName},
 	}
@@ -6014,10 +6023,9 @@ func (s *Server) IncomingCalls(ctx context.Context, params *protocol.CallHierarc
 		}
 
 		nameCol := 0
-		if defLine, ok := s.getFileLine(r.FilePath, callerLine); ok {
-			if col := findTokenColumn(defLine, callerFunc); col >= 0 {
-				nameCol = col
-			}
+		defLine, _ := s.getFileLine(r.FilePath, callerLine)
+		if col := findTokenColumn(defLine, callerFunc); col >= 0 {
+			nameCol = col
 		}
 
 		fromItem := protocol.CallHierarchyItem{
@@ -6026,8 +6034,8 @@ func (s *Server) IncomingCalls(ctx context.Context, params *protocol.CallHierarc
 			URI:   protocol.DocumentURI(uri.File(r.FilePath)),
 			Range: lineRange(callerLine - 1),
 			SelectionRange: protocol.Range{
-				Start: protocol.Position{Line: uint32(callerLine - 1), Character: uint32(nameCol)},
-				End:   protocol.Position{Line: uint32(callerLine - 1), Character: uint32(nameCol + len(callerFunc))},
+				Start: s.outPosLine(defLine, callerLine-1, nameCol),
+				End:   s.outPosLine(defLine, callerLine-1, nameCol+len(callerFunc)),
 			},
 			Data: map[string]string{"module": callerMod, "function": callerFunc},
 		}
@@ -6110,10 +6118,9 @@ func (s *Server) OutgoingCalls(ctx context.Context, params *protocol.CallHierarc
 		}
 
 		nameCol := 0
-		if defLine, ok := s.getFileLine(td.FilePath, td.Line); ok {
-			if col := findTokenColumn(defLine, key.function); col >= 0 {
-				nameCol = col
-			}
+		defLine, _ := s.getFileLine(td.FilePath, td.Line)
+		if col := findTokenColumn(defLine, key.function); col >= 0 {
+			nameCol = col
 		}
 
 		toItem := protocol.CallHierarchyItem{
@@ -6122,8 +6129,8 @@ func (s *Server) OutgoingCalls(ctx context.Context, params *protocol.CallHierarc
 			URI:   protocol.DocumentURI(uri.File(td.FilePath)),
 			Range: lineRange(td.Line - 1),
 			SelectionRange: protocol.Range{
-				Start: protocol.Position{Line: uint32(td.Line - 1), Character: uint32(nameCol)},
-				End:   protocol.Position{Line: uint32(td.Line - 1), Character: uint32(nameCol + len(key.function))},
+				Start: s.outPosLine(defLine, td.Line-1, nameCol),
+				End:   s.outPosLine(defLine, td.Line-1, nameCol+len(key.function)),
 			},
 			Data: map[string]string{"module": key.module, "function": key.function},
 		}


### PR DESCRIPTION
## The bug

LSP counts `Position.character` in **UTF-16 code units**. Dexter counts **UTF-8 bytes**. Nothing ever reconciled the two.

They agree only while a line stays ASCII, so this hid well — but a single accented character, bullet or emoji to the left of the cursor is enough to diverge:

```elixir
"São Tomé and Príncipe" => Money.new(:EUR, "19.95")
#                          ^ cursor here
# editor sends character = 37  (UTF-16 units)
# dexter needed          = 40  (UTF-8 bytes)
```

Three 2-byte characters before the cursor, so the two disagree by three. Go-to-definition, hover, references, completion and signature help all miss.

**The outbound direction is worse.** Ranges were emitted in bytes too, whatever the client counts in. An editor applying a rename replaced a span shifted off the identifier:

```
range [37,43) meaning `reason`, applied as UTF-16, selects `ason})`
  def render("400•json", %{reason: why, do: Response.init_with_error(reason)
                                        ^ braces now unbalanced
```

Silent source corruption, no error, no way for the user to know which file it happened in.

This is **not a regression** — verified against v0.7.1. `positionEncoding` has never existed in this repo; the bug dates to `bf1712c "It's an LSP now!"`.

## The fix

Every column now routes through a funnel:

| | |
|---|---|
| `inCol` | wire → byte, on the way in |
| `outPos` / `outRange` | byte → wire, when the file's lines are at hand |
| `outPosLine` / `outRangeLine` | byte → wire, when only one line is |

13 inbound sites and 55 outbound sites converted. Conversion short-circuits on ASCII lines, which is nearly all of them.

Two rules come from how other servers got this wrong:

- **Columns past end-of-line clamp** rather than erroring ([golang/go#31883](https://github.com/golang/go/issues/31883)).
- **Columns landing inside a character snap back to its first byte.** Go does not panic on a non-boundary slice the way Rust did in [the bottom-emoji bug](https://fasterthanli.me/articles/the-bottom-emoji-breaks-rust-analyzer) — it quietly yields mojibake, so nothing downstream would catch it.

## Why not negotiate utf-8?

LSP 3.17 lets a server declare `positionEncoding: "utf-8"` and skip conversion entirely. That is deliberately **not** done here.

A client only sends utf-8 if the server asks for it, so declaring nothing means every client speaks UTF-16 — one path to get right instead of two, and the busy one is exercised by every user rather than only the VS Code ones. It would also not have bought much: `BenchmarkReferencesResultConversion` puts the largest reply we produce at **227µs against 10µs**, on a request `architecture.md` measures in tens of milliseconds. Under 1%.

Negotiating would also not have been sufficient on its own. [vscode-languageserver-node#1224](https://github.com/microsoft/vscode-languageserver-node/issues/1224) has been open since 2023, so VS Code and Cursor — the first editors the README tells people to install — cannot negotiate utf-8 at all, nor can Neovim < 0.11 or Emacs ≤ 29. They need the conversion regardless.

`utf-8` and `utf-32` stay implemented and tested, so the choice is cheap to revisit. And we might do this in the future!

## Guard

A `protocol.Position` built outside the funnels compiles fine and is wrong only on non-ASCII lines, which no ordinary test covers. `TestNoUnconvertedPositions` fails the build if one appears, with instructions on which funnel to use.

## Testing

- Unit tests per helper, a **round-trip property** (byte → wire → byte is identity at every character boundary, all three encodings), and a fuzz asserting no column a hostile client can send ever splits a character.
- `TestRenameEdit_UTF16RangesLandOnTheRightText` applies the reply **exactly as a UTF-16 client would** and asserts it selects the identifier.
- **The new tests were verified to fail without the fix** — conversion was disabled and they went red.
- End-to-end over the wire against a real client: a plain utf-16 client resolves and gets correct rename ranges; a client offering utf-8 is still correctly treated as utf-16.
- `internal/lsptest` is unchanged, so the whole existing integration suite now runs through the conversion path.
- Full suite, `go vet`, `gofmt` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every LSP position path (especially rename edits); incorrect conversion would still corrupt sources on non-ASCII lines, though tests and the position guard mitigate that.
> 
> **Overview**
> Fixes **LSP column handling** so `Position.character` matches the protocol: clients send **UTF-16 code units**, while Dexter previously treated columns as **UTF-8 byte offsets**. That mismatch broke navigation and related features on lines with accents, bullets, or emoji, and outbound ranges in bytes could make **renames corrupt** the wrong span.
> 
> Adds **`position_encoding.go`** with wire↔byte conversion (`WireToByteCol` / `ByteToWireCol`), server **`inCol`** for inbound positions and **`outPos` / `outPosLine`** for emitted ranges. **`Server.positionEncoding`** defaults to UTF-16 (no `positionEncoding` negotiation). LSP handlers, rename/module edits, document symbols, highlights, call hierarchy, and **format error diagnostics** route columns through these helpers.
> 
> **Tests** cover conversion edge cases, round-trips, e2e definition/rename on non-ASCII lines, and **`TestNoUnconvertedPositions`** to block raw `protocol.Position` columns without conversion. **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc6db03033927dff92377c81796dfb6a6c4e2f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->